### PR TITLE
Call correct method on super class of AjaxSelectWidget

### DIFF
--- a/plone/app/widgets/dx.py
+++ b/plone/app/widgets/dx.py
@@ -361,7 +361,7 @@ class AjaxSelectWidget(BaseWidget):
                     return root.absolute_url()
             return ''
 
-        args = super(AjaxSelectWidget, self)._widget_args()
+        args = super(AjaxSelectWidget, self)._base_args()
         args['pattern_options']['separator'] = self.separator
 
         vocabulary_factory = getattr(self.field, 'vocabulary_factory', None)


### PR DESCRIPTION
It seems in dfe9d6fb changing the name of the method called was forgotten for AjaxSelectWidget.

The base class does not define `_widget_args`, only `_base_args`
