### PR TITLE
#240 RelatedItems widget: use a single selection for Choice fields

### DIFF
--- a/plone/app/widgets/dx.py
+++ b/plone/app/widgets/dx.py
@@ -49,6 +49,7 @@ from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import implementsOnly
 from zope.publisher.browser import TestRequest
+from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import ICollection
 from zope.schema.interfaces import IDate
 from zope.schema.interfaces import IDatetime
@@ -655,6 +656,8 @@ class RelatedItemsWidget(BaseWidget, z3cform_TextWidget):
         args['value'] = self.value
 
         args.setdefault('pattern_options', {})
+        if IChoice.providedBy(self.field):
+            args['pattern_options']['maximumSelectionSize'] = 1
         field_name = self.field and self.field.__name__ or None
         args['pattern_options'] = dict_merge(
             get_relateditems_options(self.context, args['value'],

--- a/plone/app/widgets/tests/test_dx.py
+++ b/plone/app/widgets/tests/test_dx.py
@@ -802,6 +802,42 @@ class RelatedItemsWidgetTests(unittest.TestCase):
             widget._base_args()
         )
 
+    def test_single_selection(self):
+        """The pattern_options value for maximumSelectionSize should
+        be 1 when the field only allows a single selection."""
+        from plone.app.widgets.dx import RelatedItemsFieldWidget
+        context = Mock(absolute_url=lambda: 'fake_url')
+        context.portal_properties.site_properties\
+            .getProperty.return_value = ['SomeType']
+        field = Choice(
+            __name__='selectfield',
+            values=['one', 'two', 'three'],
+        )
+        widget = RelatedItemsFieldWidget(field, self.request)
+        widget.context = context
+        widget.update()
+        base_args = widget._base_args()
+        pattern_options = base_args['pattern_options']
+        self.assertEquals(pattern_options.get('maximumSelectionSize', 0), 1)
+
+    def test_multiple_selection(self):
+        """The pattern_options key maximumSelectionSize shouldn't be
+        set when the field allows multiple selections"""
+        from plone.app.widgets.dx import RelatedItemsFieldWidget
+        context = Mock(absolute_url=lambda: 'fake_url')
+        context.portal_properties.site_properties\
+            .getProperty.return_value = ['SomeType']
+        field = List(
+            __name__='selectfield',
+            value_type=Choice(values=['one', 'two', 'three'])
+        )
+        widget = RelatedItemsFieldWidget(field, self.request)
+        widget.context = context
+        widget.update()
+        base_args = widget._base_args()
+        patterns_options = base_args['pattern_options']
+        self.assertFalse('maximumSelectionSize' in patterns_options)
+
 
 def add_mock_fti(portal):
     # Fake DX Type


### PR DESCRIPTION
Allow multiple selections for List fields.
