### PR TITLE
make the profile not do anything on plone 5

### DIFF
--- a/plone/app/widgets/configure.zcml
+++ b/plone/app/widgets/configure.zcml
@@ -240,9 +240,20 @@
   </configure>
 
   <genericsetup:registerProfile
+    zcml:condition="not-have plone-5"
     name="default"
     title="Plone Widgets"
     directory="profiles/default"
+    description="Better widgets for Plone"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    />
+
+  <genericsetup:registerProfile
+    zcml:condition="have plone-5"
+    name="default"
+    title="Plone Widgets"
+    directory="profiles/p5"
     description="Better widgets for Plone"
     provides="Products.GenericSetup.interfaces.EXTENSION"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"


### PR DESCRIPTION
Plone 5 will already have the necessary css and js included as part of the plone bundle, so let's make sure the profile doesn't do anything there if included as a dependency.
