### PR TITLE
fix querystring converter with empty input

### DIFF
--- a/plone/app/widgets/dx.py
+++ b/plone/app/widgets/dx.py
@@ -329,7 +329,7 @@ class QueryStringDataConverter(BaseDataConverter):
         :returns: Query string converted to JSON.
         :rtype: string
         """
-        if value is self.field.missing_value:
+        if not value is self.field.missing_value:
             return self.field.missing_value
         return json.dumps(value)
 
@@ -342,7 +342,7 @@ class QueryStringDataConverter(BaseDataConverter):
         :returns: Query string.
         :rtype: list
         """
-        if value is self.field.missing_value:
+        if not value:
             return self.field.missing_value
         return json.loads(value)
 

--- a/plone/app/widgets/tests/test_dx.py
+++ b/plone/app/widgets/tests/test_dx.py
@@ -757,6 +757,11 @@ class QueryStringWidgetTests(unittest.TestCase):
     def setUp(self):
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
 
+    def test_converter_empty_value(self):
+        from plone.app.widgets.dx import QueryStringDataConverter
+        converter = QueryStringDataConverter(List(), None)
+        self.assertEqual(converter.toFieldValue(u''), None)
+
     def test_widget(self):
         from plone.app.widgets.dx import QueryStringWidget
         widget = QueryStringWidget(self.request)

--- a/travis.cfg
+++ b/travis.cfg
@@ -19,3 +19,4 @@ eggs =
 
 [versions]
 coverage = 3.7
+plone.app.robotframework = 0.7.5


### PR DESCRIPTION
The querystring converter breaks if input is empty string. This fixes it. This will fix plone/mockup#296 and un-break a number of plone.app.contenttypes robot tests.
