### PR TITLE
fix date widget test in p5

### DIFF
--- a/plone/app/widgets/dx.py
+++ b/plone/app/widgets/dx.py
@@ -334,8 +334,8 @@ class QueryStringDataConverter(BaseDataConverter):
         :returns: Query string converted to JSON.
         :rtype: string
         """
-        if not value is self.field.missing_value:
-            return self.field.missing_value
+        if not value:
+            return '[]'
         return json.dumps(value)
 
     def toFieldValue(self, value):
@@ -347,9 +347,13 @@ class QueryStringDataConverter(BaseDataConverter):
         :returns: Query string.
         :rtype: list
         """
+        try:
+            value = json.loads(value)
+        except ValueError:
+            value = None
         if not value:
             return self.field.missing_value
-        return json.loads(value)
+        return value
 
 
 class BaseWidget(Widget):

--- a/plone/app/widgets/tests/robot/common.robot
+++ b/plone/app/widgets/tests/robot/common.robot
@@ -28,7 +28,7 @@ I save
   Wait until page contains  Item created
 
 I edit
-  Click link  Edit
+  Click link  css=#contentview-edit a
   Wait until page contains Element  id=form-buttons-save
 
 # ----------------------------------------------------------------------------

--- a/plone/app/widgets/tests/test_dx.py
+++ b/plone/app/widgets/tests/test_dx.py
@@ -757,10 +757,17 @@ class QueryStringWidgetTests(unittest.TestCase):
     def setUp(self):
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
 
+    def test_converter_toWidgetValue(self):
+        from plone.app.widgets.dx import QueryStringDataConverter
+        converter = QueryStringDataConverter(List(), None)
+        self.assertEqual(converter.toWidgetValue(None), u'[]')
+        self.assertEqual(converter.toWidgetValue([]), u'[]')
+
     def test_converter_empty_value(self):
         from plone.app.widgets.dx import QueryStringDataConverter
         converter = QueryStringDataConverter(List(), None)
         self.assertEqual(converter.toFieldValue(u''), None)
+        self.assertEqual(converter.toFieldValue(u'[]'), None)
 
     def test_widget(self):
         from plone.app.widgets.dx import QueryStringWidget


### PR DESCRIPTION
"Click link  Edit" no longer works due to the icon span; this should work in p4 and p5.
