### PR TITLE
Remove pinning text field to TinyMCEWidget

### DIFF
--- a/plone/app/widgets/at_bbb.py
+++ b/plone/app/widgets/at_bbb.py
@@ -76,12 +76,6 @@ class MetadataExtender(object):
                     vocabulary="plone.app.vocabularies.Users",
                 )
 
-            if field.__name__ in ['text']:
-                field.widget = at.TinyMCEWidget(
-                    label=old.label,
-                    description=old.description,
-                )
-
             if field.__name__ == 'query':
                 field.widget = at.QueryStringWidget(
                     label=old.label,


### PR DESCRIPTION
A text Schema Field should be not directly pinned to TinyMCEWidget.

Plone is currently constructed in a way, that you can install and use another visual editor like for example ckeditor.

If you do it in this way you can't use another editor or you have two diffrent editors loaded, like it was in one of our plattforms, if you have more than one rich text field in a content schema.

Happended in a Plone 4.3.2 plattform.
