### PR TITLE
improvements to RelatedItemsWidget

### DIFF
--- a/plone/app/widgets/browser/configure.zcml
+++ b/plone/app/widgets/browser/configure.zcml
@@ -14,6 +14,13 @@
     />
 
   <browser:page
+    name="getSource"
+    for="z3c.form.interfaces.IWidget"
+    class=".vocabulary.SourceView"
+    permission="zope.Public"
+    />
+
+  <browser:page
     name="fileUpload"
     for="Products.CMFCore.interfaces._content.IFolderish"
     class=".file.FileUploadView"

--- a/plone/app/widgets/browser/vocabulary.py
+++ b/plone/app/widgets/browser/vocabulary.py
@@ -1,18 +1,23 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import getSecurityManager
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five import BrowserView
-from Products.ZCTextIndex.ParseTree import ParseError
 from logging import getLogger
-from plone.app.vocabularies.interfaces import ISlicableVocabulary
+from plone.app.querystring import queryparser
 from plone.app.widgets.interfaces import IFieldPermissionChecker
+from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
+from plone.supermodel.utils import mergedTaggedValueDict
 from types import FunctionType
+from zope.component import getUtility
 from zope.component import queryAdapter
 from zope.component import queryUtility
+from zope.schema.interfaces import ICollection
 from zope.schema.interfaces import IVocabularyFactory
-
+from zope.security.interfaces import IPermission
 import inspect
+import itertools
 import json
 
 logger = getLogger(__name__)
@@ -39,14 +44,11 @@ _unsafe_metadata = ['Creator', 'listCreators', 'author_name', 'commentors']
 _safe_callable_metadata = ['getURL', 'getPath']
 
 
-class VocabularyView(BrowserView):
+class VocabLookupException(Exception):
+    pass
 
-    def error(self):
-        return json.dumps({
-            'results': [],
-            'total': 0,
-            'error': True
-        })
+
+class BaseVocabularyView(BrowserView):
 
     def __call__(self):
         """
@@ -66,13 +68,127 @@ class VocabularyView(BrowserView):
             size: size of paged results
         }
         """
-        context = self.context
+        context = self.get_context()
         self.request.response.setHeader("Content-type", "application/json")
 
+        try:
+            vocabulary = self.get_vocabulary()
+        except VocabLookupException, e:
+            return json.dumps({'error': e.message})
+
+        results_are_brains = False
+        if hasattr(vocabulary, 'search_catalog'):
+            query = self.parsed_query()
+            results = vocabulary.search_catalog(query)
+            results_are_brains = True
+        elif hasattr(vocabulary, 'search'):
+            try:
+                query = self.parsed_query()['SearchableText']['query']
+            except KeyError:
+                results = iter(vocabulary)
+            else:
+                results = vocabulary.search(query)
+        else:
+            results = vocabulary
+
+        try:
+            total = len(results)
+        except TypeError:
+            total = 0  # do not error if object does not support __len__
+                       # we'll check again later if we can figure some size
+                       # out
+
+        # get batch
+        batch = _parseJSON(self.request.get('batch', ''))
+        if batch and ('size' not in batch or 'page' not in batch):
+            batch = None  # batching not providing correct options
+        if batch:
+            # must be slicable for batching support
+            page = int(batch['page'])
+            # page is being passed in is 1-based
+            start = (max(page - 1, 0)) * int(batch['size'])
+            end = start + int(batch['size'])
+            # Try __getitem__-based slice, then iterator slice.
+            # The iterator slice has to consume the iterator through
+            # to the desired slice, but that shouldn't be the end
+            # of the world because at some point the user will hopefully
+            # give up scrolling and search instead.
+            try:
+                results = results[start:end]
+            except TypeError:
+                results = itertools.islice(results, start, end)
+
+        # build result items
+        items = []
+
+        attributes = _parseJSON(self.request.get('attributes', ''))
+        if isinstance(attributes, basestring) and attributes:
+            attributes = attributes.split(',')
+
+        if attributes:
+            portal = getToolByName(context, 'portal_url').getPortalObject()
+            base_path = '/'.join(portal.getPhysicalPath())
+            for vocab_item in results:
+                if not results_are_brains:
+                    vocab_item = vocab_item.value
+                item = {}
+                for attr in attributes:
+                    key = attr
+                    if ':' in attr:
+                        key, attr = attr.split(':', 1)
+                    if attr in _unsafe_metadata:
+                        continue
+                    if key == 'path':
+                        attr = 'getPath'
+                    val = getattr(vocab_item, attr, None)
+                    if callable(val):
+                        if attr in _safe_callable_metadata:
+                            val = val()
+                        else:
+                            continue
+                    if key == 'path':
+                        val = val[len(base_path):]
+                    item[key] = val
+                items.append(item)
+        else:
+            for item in results:
+                items.append({'id': item.token, 'text': item.title})
+
+        if total == 0:
+            total = len(items)
+
+        return json.dumps({
+            'results': items,
+            'total': total
+        })
+
+    def parsed_query(self, ):
+        query = _parseJSON(self.request.get('query', '')) or {}
+        if query:
+            parsed = queryparser.parseFormquery(
+                self.get_context(), query['criteria'])
+            if 'sort_on' in query:
+                parsed['sort_on'] = query['sort_on']
+            if 'sort_order' in query:
+                parsed['sort_order'] = str(query['sort_order'])
+            query = parsed
+        return query
+
+
+class VocabularyView(BaseVocabularyView):
+    """Queries a named vocabulary and returns JSON-formatted results."""
+
+    def get_context(self):
+        return self.context
+
+    def get_vocabulary(self):
+        # Look up named vocabulary and check permission.
+
+        context = self.context
         factory_name = self.request.get('name', None)
         field_name = self.request.get('field', None)
         if not factory_name:
-            return json.dumps({'error': 'No factory provided.'})
+            raise VocabLookupException('No factory provided.')
         authorized = None
         sm = getSecurityManager()
         if (factory_name not in _permissions or
@@ -85,107 +201,57 @@ class VocabularyView(BrowserView):
                     authorized = permission_checker.validate(field_name,
                                                              factory_name)
             if not authorized:
-                return json.dumps({'error': 'Vocabulary lookup not allowed'})
+                raise VocabLookupException('Vocabulary lookup not allowed')
         # Short circuit if we are on the site root and permission is
         # in global registry
         elif not sm.checkPermission(_permissions[factory_name], context):
-            return json.dumps({'error': 'Vocabulary lookup not allowed'})
+            raise VocabLookupException('Vocabulary lookup not allowed')
 
         factory = queryUtility(IVocabularyFactory, factory_name)
         if not factory:
-            return json.dumps({
-                'error': 'No factory with name "%s" exists.' % factory_name})
+            raise VocabLookupException(
+                'No factory with name "%s" exists.' % factory_name)
 
-        # check if factory accepts query argument
-        query = _parseJSON(self.request.get('query', ''))
-        batch = _parseJSON(self.request.get('batch', ''))
-
+        # This part is for backwards-compatibility with the first
+        # generation of vocabularies created for plone.app.widgets,
+        # which take the (unparsed) query as a parameter of the vocab
+        # factory rather than as a separate search method.
         if type(factory) is FunctionType:
             factory_spec = inspect.getargspec(factory)
         else:
             factory_spec = inspect.getargspec(factory.__call__)
-        try:
-            supports_batch = False
-            vocabulary = None
-            if query and 'query' in factory_spec.args:
-                if 'batch' in factory_spec.args:
-                    vocabulary = factory(self.context,
-                                         query=query, batch=batch)
-                    supports_batch = True
-                else:
-                    vocabulary = factory(self.context, query=query)
-            elif query:
-                raise KeyError("The vocabulary factory %s does not support "
-                               "query arguments",
-                               factory)
-
-            if batch and supports_batch:
-                    vocabulary = factory(context, query, batch)
-            elif query:
-                    vocabulary = factory(context, query)
-            else:
-                vocabulary = factory(context)
-
-        except (TypeError, ParseError):
-            raise
-            return self.error()
-
-        try:
-            total = len(vocabulary)
-        except TypeError:
-            total = 0  # do not error if object does not support __len__
-                       # we'll check again later if we can figure some size
-                       # out
-        if batch and ('size' not in batch or 'page' not in batch):
-            batch = None  # batching not providing correct options
-            logger.error("A vocabulary request contained bad batch "
-                         "information. The batch information is ignored.")
-        if batch and not supports_batch and \
-                ISlicableVocabulary.providedBy(vocabulary):
-            # must be slicable for batching support
-            page = int(batch['page'])
-            # page is being passed in is 1-based
-            start = (max(page-1, 0)) * int(batch['size'])
-            end = start + int(batch['size'])
-            vocabulary = vocabulary[start:end]
-
-        items = []
-
-        attributes = _parseJSON(self.request.get('attributes', ''))
-        if isinstance(attributes, basestring) and attributes:
-            attributes = attributes.split(',')
-
-        if attributes:
-            base_path = '/'.join(context.getPhysicalPath())
-            for vocab_item in vocabulary:
-                item = {}
-                for attr in attributes:
-                    key = attr
-                    if ':' in attr:
-                        key, attr = attr.split(':', 1)
-                    if attr in _unsafe_metadata:
-                        continue
-                    if key == 'path':
-                        attr = 'getPath'
-                    vocab_value = vocab_item.value
-                    val = getattr(vocab_value, attr, None)
-                    if callable(val):
-                        if attr in _safe_callable_metadata:
-                            val = val()
-                        else:
-                            continue
-                    if key == 'path':
-                        val = val[len(base_path):]
-                    item[key] = val
-                items.append(item)
+        query = _parseJSON(self.request.get('query', ''))
+        if query and 'query' in factory_spec.args:
+            vocabulary = factory(context, query=query)
         else:
-            for item in vocabulary:
-                items.append({'id': item.token, 'text': item.title})
+            # This is what is reached for non-legacy vocabularies.
+            vocabulary = factory(context)
 
-        if total == 0:
-            total = len(items)
+        return vocabulary
 
-        return json.dumps({
-            'results': items,
-            'total': total
-        })
+
+class SourceView(BaseVocabularyView):
+    """Queries a field's source and returns JSON-formatted results."""
+
+    def get_context(self):
+        return self.context.context
+
+    def get_vocabulary(self):
+        widget = self.context
+        field = widget.field.bind(widget.context)
+
+        # check field's write permission
+        info = mergedTaggedValueDict(field.interface, WRITE_PERMISSIONS_KEY)
+        permission_name = info.get(field.__name__, 'cmf.ModifyPortalContent')
+        permission = queryUtility(IPermission, name=permission_name)
+        if permission is None:
+            permission = getUtility(
+                IPermission, name='cmf.ModifyPortalContent')
+        if not getSecurityManager().checkPermission(
+                permission.title, self.get_context()):
+            raise VocabLookupException('Vocabulary lookup not allowed.')
+
+        if ICollection.providedBy(field):
+            return field.value_type.vocabulary
+        else:
+            return field.vocabulary

--- a/plone/app/widgets/configure.zcml
+++ b/plone/app/widgets/configure.zcml
@@ -156,6 +156,7 @@
     <adapter factory=".dx.SelectWidgetConverter" />
     <adapter factory=".dx.AjaxSelectWidgetConverter" />
     <adapter factory=".dx.QueryStringDataConverter" />
+    <adapter factory=".dx.RelationChoiceRelatedItemsWidgetConverter" />
     <adapter factory=".dx.RelatedItemsDataConverter" />
   </configure>
 
@@ -235,6 +236,12 @@
             for="z3c.relationfield.interfaces.IRelationList
                   z3c.form.interfaces.IFormLayer"
             />
+
+    <adapter
+      factory=".dx.RelatedItemsFieldWidget"
+      for="zope.schema.interfaces.IChoice
+           plone.app.vocabularies.catalog.CatalogSource
+           z3c.form.interfaces.IFormLayer" />
 
     <adapter factory=".dx.QueryStringFieldWidget" />
     <adapter factory=".dx.RichTextFieldWidget" />

--- a/plone/app/widgets/tests/test_dx.py
+++ b/plone/app/widgets/tests/test_dx.py
@@ -35,6 +35,7 @@ from zope.schema import TextLine
 from zope.schema import Tuple
 from zope.schema import Set
 
+import mock
 import json
 
 try:
@@ -169,6 +170,16 @@ class DateWidgetTests(unittest.TestCase):
             '21-10-30',
             converter.toWidgetValue(date(21, 10, 30)),
         )
+
+    def test_fieldwidget(self):
+        from plone.app.widgets.dx import DateWidget
+        from plone.app.widgets.dx import DateFieldWidget
+        field = Mock(__name__='field', title=u'', required=True)
+        request = Mock()
+        widget = DateFieldWidget(field, request)
+        self.assertTrue(isinstance(widget, DateWidget))
+        self.assertIs(widget.field, field)
+        self.assertIs(widget.request, request)
 
 
 class DatetimeWidgetTests(unittest.TestCase):
@@ -305,6 +316,16 @@ class DatetimeWidgetTests(unittest.TestCase):
         # cleanup
         self.widget.context = None
 
+    def test_fieldwidget(self):
+        from plone.app.widgets.dx import DatetimeWidget
+        from plone.app.widgets.dx import DatetimeFieldWidget
+        field = Mock(__name__='field', title=u'', required=True)
+        request = Mock()
+        widget = DatetimeFieldWidget(field, request)
+        self.assertTrue(isinstance(widget, DatetimeWidget))
+        self.assertIs(widget.field, field)
+        self.assertIs(widget.request, request)
+
 
 class SelectWidgetTests(unittest.TestCase):
 
@@ -396,8 +417,8 @@ class SelectWidgetTests(unittest.TestCase):
             {
                 'multiple': True,
                 'name': None,
-                'pattern_options': {'orderable': True, 'multiple': True,
-                                    'separator': '.'},
+                'pattern_options': {
+                    'orderable': True, 'multiple': True, 'separator': '.'},
                 'pattern': 'select2',
                 'value': (),
                 'items': [
@@ -421,8 +442,8 @@ class SelectWidgetTests(unittest.TestCase):
             {
                 'multiple': True,
                 'name': None,
-                'pattern_options': {'orderable': True, 'multiple': True,
-                                    'separator': ';'},
+                'pattern_options': {
+                    'orderable': True, 'multiple': True, 'separator': ';'},
                 'pattern': 'select2',
                 'value': (),
                 'items': [
@@ -447,7 +468,8 @@ class SelectWidgetTests(unittest.TestCase):
             {
                 'multiple': True,
                 'name': None,
-                'pattern_options': {'multiple': True, 'separator': ';'},
+                'pattern_options': {
+                    'multiple': True, 'separator': ';'},
                 'pattern': 'select2',
                 'value': (),
                 'items': [
@@ -660,6 +682,29 @@ class AjaxSelectWidgetTests(unittest.TestCase):
             widget._base_args(),
         )
 
+    def test_widget_choice(self):
+        from plone.app.widgets.dx import AjaxSelectWidget
+        from zope.schema.interfaces import ISource
+        widget = AjaxSelectWidget(self.request)
+        source = Mock()
+        alsoProvides(source, ISource)
+        widget.field = Choice(__name__='choicefield', source=source)
+        widget.name = 'choicefield'
+        self.assertEqual(
+            {
+                'name': 'choicefield',
+                'value': u'',
+                'pattern': 'select2',
+                'pattern_options': {
+                    'separator': ';',
+                    'maximumSelectionSize': 1,
+                    'vocabularyUrl':
+                    'http://127.0.0.1/++widget++choicefield/@@getSource',
+                    },
+            },
+            widget._base_args(),
+        )
+
     def test_widget_addform_url_on_addform(self):
         from plone.app.widgets.dx import AjaxSelectWidget
         widget = AjaxSelectWidget(self.request)
@@ -751,6 +796,27 @@ class AjaxSelectWidgetTests(unittest.TestCase):
             '123;456;789',
         )
 
+    def test_fieldwidget(self):
+        from plone.app.widgets.dx import AjaxSelectWidget
+        from plone.app.widgets.dx import AjaxSelectFieldWidget
+        field = Mock(__name__='field', title=u'', required=True)
+        request = Mock()
+        widget = AjaxSelectFieldWidget(field, request)
+        self.assertTrue(isinstance(widget, AjaxSelectWidget))
+        self.assertIs(widget.field, field)
+        self.assertIs(widget.request, request)
+
+    def test_fieldwidget_sequence(self):
+        from plone.app.widgets.dx import AjaxSelectWidget
+        from plone.app.widgets.dx import AjaxSelectFieldWidget
+        field = Mock(__name__='field', title=u'', required=True)
+        vocabulary = Mock()
+        request = Mock()
+        widget = AjaxSelectFieldWidget(field, vocabulary, request)
+        self.assertTrue(isinstance(widget, AjaxSelectWidget))
+        self.assertIs(widget.field, field)
+        self.assertIs(widget.request, request)
+
 
 class QueryStringWidgetTests(unittest.TestCase):
 
@@ -837,19 +903,98 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         """The pattern_options key maximumSelectionSize shouldn't be
         set when the field allows multiple selections"""
         from plone.app.widgets.dx import RelatedItemsFieldWidget
+        from zope.schema.interfaces import ISource
+        from zope.schema.vocabulary import VocabularyRegistry
+
         context = Mock(absolute_url=lambda: 'fake_url')
         context.portal_properties.site_properties\
             .getProperty.return_value = ['SomeType']
         field = List(
             __name__='selectfield',
-            value_type=Choice(values=['one', 'two', 'three'])
+            value_type=Choice(vocabulary='foobar')
         )
         widget = RelatedItemsFieldWidget(field, self.request)
         widget.context = context
-        widget.update()
-        base_args = widget._base_args()
+
+        vocab = Mock()
+        alsoProvides(vocab, ISource)
+        with mock.patch.object(VocabularyRegistry, 'get', return_value=vocab):
+            widget.update()
+            base_args = widget._base_args()
         patterns_options = base_args['pattern_options']
         self.assertFalse('maximumSelectionSize' in patterns_options)
+        self.assertEqual(
+            patterns_options['vocabularyUrl'],
+            '/@@getVocabulary?name=foobar&field=selectfield',
+            )
+
+    def test_converter_RelationChoice(self):
+        from plone.app.widgets.dx import \
+            RelationChoiceRelatedItemsWidgetConverter
+        brain = Mock(getObject=Mock(return_value='obj'))
+        portal_catalog = Mock(return_value=[brain])
+        widget = Mock()
+        converter = RelationChoiceRelatedItemsWidgetConverter(
+            TextLine(), widget)
+
+        with mock.patch('plone.app.widgets.dx.IUUID', return_value='id'):
+            self.assertEqual(converter.toWidgetValue('obj'), 'id')
+        self.assertEqual(converter.toWidgetValue(None), None)
+
+        with mock.patch(
+                'plone.app.widgets.dx.getToolByName',
+                return_value=portal_catalog):
+            self.assertEqual(converter.toFieldValue('id'), 'obj')
+        self.assertEqual(converter.toFieldValue(None), None)
+
+    def test_converter_RelationList(self):
+        from plone.app.widgets.dx import RelatedItemsDataConverter
+        from plone.app.widgets.dx import IRelationList
+        field = List()
+        alsoProvides(field, IRelationList)
+        brain1 = Mock(getObject=Mock(return_value='obj1'))
+        brain2 = Mock(getObject=Mock(return_value='obj2'))
+        portal_catalog = Mock(return_value=[brain1, brain2])
+        widget = Mock(separator=';')
+        converter = RelatedItemsDataConverter(field, widget)
+
+        self.assertEqual(converter.toWidgetValue(None), None)
+        with mock.patch(
+                'plone.app.widgets.dx.IUUID', side_effect=['id1', 'id2']):
+            self.assertEqual(
+                converter.toWidgetValue(['obj1', 'obj2']), 'id1;id2')
+
+        self.assertEqual(converter.toFieldValue(None), None)
+        with mock.patch(
+                'plone.app.widgets.dx.getToolByName',
+                return_value=portal_catalog):
+            self.assertEqual(
+                converter.toFieldValue('id1;id2'), ['obj1', 'obj2'])
+
+    def test_converter_List_of_Choice(self):
+        from plone.app.widgets.dx import RelatedItemsDataConverter
+        field = List()
+        widget = Mock(separator=';')
+        converter = RelatedItemsDataConverter(field, widget)
+
+        self.assertEqual(converter.toWidgetValue(None), None)
+        self.assertEqual(
+            converter.toWidgetValue(['id1', 'id2']), 'id1;id2')
+
+        self.assertEqual(converter.toFieldValue(None), None)
+        self.assertEqual(
+            converter.toFieldValue('id1;id2'), ['id1', 'id2'])
+
+    def test_fieldwidget(self):
+        from plone.app.widgets.dx import RelatedItemsWidget
+        from plone.app.widgets.dx import RelatedItemsFieldWidget
+        field = Mock(__name__='field', title=u'', required=True)
+        vocabulary = Mock()
+        request = Mock()
+        widget = RelatedItemsFieldWidget(field, vocabulary, request)
+        self.assertTrue(isinstance(widget, RelatedItemsWidget))
+        self.assertIs(widget.field, field)
+        self.assertIs(widget.request, request)
 
 
 def add_mock_fti(portal):


### PR DESCRIPTION
Note: This pull request depends on plone/plone.app.vocabularies#6; please merge that first.
- Add a @@getSource view which can be used to query a source instead of a named vocabulary for the ajax select and related items widgets. It is used for the Dexterity widgets only (since AT widgets don't support zope.schema sources, afaik) if the field's vocabulary was set to an object instead of a string. The field's write permission is checked to see if the source can be queried.
- The preferred API for vocabularies to support querying has changed. The old way was to pass an unparsed formquery to the vocabulary factory (this is still supported for backwards compatibility). Now the vocabulary or source can provide one of these methods:
  1. search_catalog - Takes a parsed formquery and returns an iterator of catalog brains.
  2. search - Takes a string query and returns an iterator of vocabulary terms.
  
  This was done for 2 reasons:
  1. It works even for vocabularies and sources that are instantiated at instance startup.
  2. It provides a 'search' method which mimics the interface expected of sources by formlib and plone.app.contenttree widgets, so should make it easier to migrate old code.
- The getVocabulary and getSource views now handle batching themselves instead of requiring the vocabulary to support slicing. It tries **getitem** with a slice first, and if that fails it treats the results as an iterator and uses islice. This means all items are consumed up to the start of the slice, but that was happening anyway with the CatalogVocabulary's **getitem** implementation, and it's probably not too big a concern since users will probably give up scrolling and search instead.
- Added a converter for the RelatedItemsWidget when used with a RelationChoice field. (i.e. selecting a single object)
- Fixed converters to make the RelatedItemsWidget work with text and choice fields that only want to store the UID of the selected object(s) rather than a full-blown relation.
- The RelatedItemsWidget is registered (in plone 5 only) as the default widget for all Choice fields using plone.app.vocabularies.catalog.CatalogSource as a source.
- Added tests for new code and improved coverage a bit.
