### PR TITLE
Change getVocabulary to work also on non IPloneSiteRoot contexts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.8.0 (unreleased)
 ------------------
 
-- Change ``getVocabulary`` to work also on non IPloneSiteRoot contexts.
+- Allow ``getVocabulary`` calls without a fieldname on INavigationRoot instead
+  of IPloneSiteRoot. This adds compatibility for Lineage based subsites.
   [thet]
 
 - Use widget bundle from mockup's build directory, if mockup is installed. In

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.8.0 (unreleased)
 ------------------
 
+- Change ``getVocabulary`` to work also on non IPloneSiteRoot contexts.
+  [thet]
+
 - Use widget bundle from mockup's build directory, if mockup is installed. In
   this case, you need to build the widgets bundle in the mockup directory.
   [thet]

--- a/plone/app/widgets/browser/vocabulary.py
+++ b/plone/app/widgets/browser/vocabulary.py
@@ -190,20 +190,22 @@ class VocabularyView(BaseVocabularyView):
             raise VocabLookupException('No factory provided.')
         authorized = None
         sm = getSecurityManager()
-        if (factory_name not in _permissions or
-                not IPloneSiteRoot.providedBy(context)):
+        if factory_name in _permissions:
+            # Short circuit if permission is in global registry
+            authorized = sm.checkPermission(
+                _permissions[factory_name], context
+            )
+        elif field_name:
             # Check field specific permission
-            if field_name:
-                permission_checker = queryAdapter(context,
-                                                  IFieldPermissionChecker)
-                if permission_checker is not None:
-                    authorized = permission_checker.validate(field_name,
-                                                             factory_name)
-            if not authorized:
-                raise VocabLookupException('Vocabulary lookup not allowed')
-        # Short circuit if we are on the site root and permission is
-        # in global registry
-        elif not sm.checkPermission(_permissions[factory_name], context):
+            permission_checker = queryAdapter(
+                context, IFieldPermissionChecker
+            )
+            if permission_checker is not None:
+                authorized = permission_checker.validate(
+                    field_name, factory_name
+                )
+
+        if not authorized:
             raise VocabLookupException('Vocabulary lookup not allowed')
 
         factory = queryUtility(IVocabularyFactory, factory_name)

--- a/plone/app/widgets/browser/vocabulary.py
+++ b/plone/app/widgets/browser/vocabulary.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five import BrowserView
 from logging import getLogger
+from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.querystring import queryparser
 from plone.app.widgets.interfaces import IFieldPermissionChecker
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
@@ -190,7 +190,8 @@ class VocabularyView(BaseVocabularyView):
             raise VocabLookupException('No factory provided.')
         authorized = None
         sm = getSecurityManager()
-        if factory_name in _permissions:
+        if factory_name in _permissions\
+                and INavigationRoot.providedBy(context):
             # Short circuit if permission is in global registry
             authorized = sm.checkPermission(
                 _permissions[factory_name], context


### PR DESCRIPTION
@alecpm i removed the check for IPloneSiteRoot, because getVocabulary should also be able to be called on other contexts, e.g. on INavigationRoot contexts from subsites in a collective.lineage based site.
https://github.com/plone/plone.app.widgets/compare/1.x...thet-getVocabulary-non-IPloneSiteRoot?expand=1#diff-cc8621ac4fb1caf4495921abbc02f895L194

Does this introduce a security problem, because e.g. a vocabulary could be customized on contexts other than IPloneSiteRoot? If this is the reason behind the IPloneSiteRoot check, it doesn't avoid customizing in IPloneSiteRoot directly. I marked the 

