### PR TITLE
1.x branch: enable more TinyMCE control panel feature mappings: textcolor plugin, table style/classname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Incorporate 'textcolor' plugin into configuration.  This ships with 
+  the included TinyMCE, and has configurable 'forecolor' and 'backcolor'
+  buttons in Plone 4 TinyMCE control panel.
+  [seanupton]
+
 - Fix vocabulary item path. This fixes issues when browsing through
   collective.lineage subsites.
   [petschki]

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -205,7 +205,7 @@ def get_tinymce_options(context, field, request):
             '-advlist -autolink -lists -charmap -print -preview ' \
             '-anchor -searchreplace -visualblocks -code -fullscreen ' \
             '-insertdatetime -media -table -contextmenu -paste ' \
-            '-plonelink -ploneimage'
+            '-plonelink -ploneimage -textcolor'
 
         # FIXME: map old names to new names in the configuration for plone5
         # and notify migration-team
@@ -329,7 +329,6 @@ def get_tinymce_options(context, field, request):
         # nonbreaking, pagebreak - do not show up
         # emoticons - does not show up
         # ltr, rtl (directionality plugin) - do not show up
-        # forecolor, backcolor - buttons do not show up
         # spellchecker - button does not show up
         # visualblocks - do not show any additional borders/lines around p / h2
         # visualchars - does not show up

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -345,6 +345,12 @@ def get_tinymce_options(context, field, request):
             '{code} {fullscreen} spellchecker'.format(**button_settings)
         config['toolbar'] = toolbar
 
+        # Plone 4.x TinyMCE panel defines table format/style title, classname:
+        config['table_class_list'] = map(
+            lambda pair: {'title': pair[0], 'value': pair[1]},
+            [e.strip().split('|') for e in utility.tablestyles.split('\n')]
+        )
+
         # contextmenu is no longer available, use this setting for menubar
         # FIXME: plone5 rename setting
         # xxx toolbar_external (theme_advanced_toolbar_location not available


### PR DESCRIPTION
existing forecolor and backcolor button options will work if enabled (opt-in) in Plone 4 control panel, but only if this plugin is enabled.  This does not change user experience in OOTB TinyMCE control panel configuration, so low risk.  Includes change log entry and comment fix.

Second commit adds mapping of table styles in TinyMCE plone 4 control panel to table_class_list in TinyMCE JSON configuration.