### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.7
 addons:
-  sauce_connect:
+  - sauce_connect:
     - username: $SAUCE_USERNAME
     - access_key: $SAUCE_ACCESS_KEY
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ addons:
     - access_key: $SAUCE_ACCESS_KEY
 install:
   - mkdir -p buildout-cache/downloads
-  - python bootstrap.py -c travis.cfg
+# Keep the setuptools and zc.buildout versions in sync with travis.cfg.
+# Or remove the -N (non-newest) from the buildout run in .travis.yml.
+  - python bootstrap.py -c travis.cfg --buildout-version=2.5.0 --setuptools-version=19.6.2
+  - bin/buildout -N -c travis.cfg annotate
   - bin/buildout -N -t 3 -c travis.cfg
 script:
   - if [ "$BROWSER" != "code-analysis" ]; then export ROBOT_DESIRED_CAPABILITIES="$BROWSER,tunnel-identifier:$TRAVIS_JOB_NUMBER"; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New:
 
 Fixes:
 
+- Fixed timing issue in robot tests.  [maurits]
+
 - Use plone i18n domain
   [staeff]
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/develop.cfg
+++ b/develop.cfg
@@ -12,15 +12,6 @@ parts +=
 
 develop = .
 
-extensions = mr.developer
-auto-checkout = *
-
-[sources]
-# Looks like, `develop = .` doesn't work here - buildout is downloading the
-# plone.app.widgets 1.5.0 egg. So we checkout plone.app.widgets to the buildout
-# directory path.
-plone.app.widgets = git git@github.com:plone/plone.app.widgets.git branch=master full-path=${buildout:directory}
-
 [robot]
 recipe = zc.recipe.egg
 eggs =
@@ -48,4 +39,3 @@ eggs =
 recipe = zc.recipe.testrunner
 eggs = plone.app.widgets[test,archetypes,dexterity]
 defaults = ['--auto-color', '--auto-progress']
-

--- a/develop.cfg
+++ b/develop.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://dist.plone.org/release/4.3-latest/versions.cfg
+    http://dist.plone.org/release/5-latest/versions.cfg
     sphinx.cfg
     versions.cfg
 

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -14,12 +14,12 @@ Querystring Widget rows appear and disappear correctly
   Given I'm logged in as a 'Site Administrator'
     And I create a collection  My Collection
         Wait For Condition  return $('body.patterns-loaded').size() > 0
-        Page should contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1)
+        Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1)
         Page should not contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When I select criteria index in row  1  Expiration date
-        Page should contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2) .querystring-criteria-remove
-        Page should contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1) .querystring-criteria-remove
         Page should not contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
 
@@ -82,7 +82,7 @@ Collection Creation works
    When I select criteria index in row  1  Location
     And I select criteria operator in row  1  Absolute path
     And I save
-        Page should contain Element  jquery=.contenttype-collection:contains(My Collection)
+        Wait until page contains Element  jquery=.contenttype-collection:contains(My Collection)
 
 
 *** Keywords ***
@@ -102,7 +102,7 @@ I select criteria operator in row
 Operator slave field becomes visible
   [Arguments]  ${number}  ${selector}
   ${criteria_row} =  Convert to String  ${querywidget_selector} .querystring-criteria-wrapper:nth-child(${number})
-  Page should contain Element  css=${criteria_row} .querystring-criteria-value ${selector}
+  Wait until page contains Element  css=${criteria_row} .querystring-criteria-value ${selector}
 
 Date criteria operators are functional
   [Arguments]  ${number}

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -29,6 +29,3 @@ input = inline:
     bin/zopepy setup.py upload_sphinx
 output = ${buildout:directory}/bin/sphinxupload
 mode = 755
-
-[versions]
-pygments = 1.6

--- a/travis.cfg
+++ b/travis.cfg
@@ -9,7 +9,6 @@ package-name = plone.app.widgets
 package-extras = [test,archetypes,dexterity]
 test-eggs = Pillow
 parts += extra
-develop += plone.app.contenttypes
 
 [extra]
 recipe = zc.recipe.egg
@@ -21,7 +20,6 @@ eggs =
 [versions]
 coverage = 3.7
 plone.app.robotframework = 0.8.2
-plone.app.contenttypes =
 # Keep the setuptools and zc.buildout versions in sync with .travis.yml.
 # Or remove the -N (non-newest) from the buildout run in .travis.yml.
 setuptools = 19.6.2

--- a/travis.cfg
+++ b/travis.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/travis-4.3.x.cfg
+    https://raw.github.com/collective/buildout.plonetest/master/travis-5.x.cfg
     versions.cfg
 allow-hosts +=
     code.google.com
@@ -16,11 +16,3 @@ eggs =
     flake8
     createcoverage
     coveralls
-
-[versions]
-coverage = 3.7
-plone.app.robotframework = 0.8.2
-# Keep the setuptools and zc.buildout versions in sync with .travis.yml.
-# Or remove the -N (non-newest) from the buildout run in .travis.yml.
-setuptools = 19.6.2
-zc.buildout = 2.5.0

--- a/travis.cfg
+++ b/travis.cfg
@@ -22,3 +22,7 @@ eggs =
 coverage = 3.7
 plone.app.robotframework = 0.8.2
 plone.app.contenttypes =
+# Keep the setuptools and zc.buildout versions in sync with .travis.yml.
+# Or remove the -N (non-newest) from the buildout run in .travis.yml.
+setuptools = 19.6.2
+zc.buildout = 2.5.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -9,16 +9,7 @@ plone.app.widgets =
 # Or remove the -N (non-newest) from the buildout run in .travis.yml.
 setuptools = 19.6.2
 zc.buildout = 2.5.0
-# Robot Test Env
-plone.app.robotframework = 0.9.4
-robotframework = 2.8.4
-robotframework-selenium2library = 1.5.0
-robotsuite = 1.5.0
-selenium = 2.42.1
-robotframework-selenium2screenshots = 0.4.0
-sphinxcontrib-robotframework = 0.4.3
-robotframework-debuglibrary = 0.3
-# Test Env
+# Other pins
 Babel = 1.3
 argh = 0.26.1
 collective.recipe.cmd = 0.11

--- a/versions.cfg
+++ b/versions.cfg
@@ -4,6 +4,8 @@ versions = versions
 show-picked-versions = true
 
 [versions]
+# Unpin ourselves:
+plone.app.widgets =
 # Robot Test Env
 plone.app.robotframework = 0.9.4
 robotframework = 2.8.4

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends = https://raw.github.com/plone/plone.app.event/1.2.x/versions.cfg
 versions = versions
+show-picked-versions = true
 
 [versions]
 # Robot Test Env
@@ -13,9 +14,18 @@ robotframework-selenium2screenshots = 0.4.0
 sphinxcontrib-robotframework = 0.4.3
 robotframework-debuglibrary = 0.3
 # Test Env
-collective.xmltestreport = 1.3.1
-mock = 1.0.1
-zope.testrunner = 4.1.1
-pep8 = 1.4.6
 Babel = 1.3
 Pygments = 1.6
+collective.recipe.cmd = 0.11
+collective.xmltestreport = 1.3.1
+coveralls = 1.1
+createcoverage = 1.5
+docopt = 0.6.2
+flake8 = 2.5.2
+hexagonit.recipe.download = 1.7
+mccabe = 0.4.0
+mock = 1.0.1
+plone.app.jquery = 1.11.2
+pyflakes = 1.0.0
+requests = 2.9.1
+zope.testrunner = 4.1.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -9,6 +9,8 @@ plone.app.widgets =
 # Or remove the -N (non-newest) from the buildout run in .travis.yml.
 setuptools = 19.6.2
 zc.buildout = 2.5.0
+# Use latest selenium:
+selenium = 2.51.1
 # Other pins
 Babel = 1.3
 argh = 0.26.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,11 +1,14 @@
 [buildout]
-extends = https://raw.github.com/plone/plone.app.event/1.2.x/versions.cfg
 versions = versions
 show-picked-versions = true
 
 [versions]
 # Unpin ourselves:
 plone.app.widgets =
+# Keep the setuptools and zc.buildout versions in sync with .travis.yml.
+# Or remove the -N (non-newest) from the buildout run in .travis.yml.
+setuptools = 19.6.2
+zc.buildout = 2.5.0
 # Robot Test Env
 plone.app.robotframework = 0.9.4
 robotframework = 2.8.4
@@ -17,17 +20,25 @@ sphinxcontrib-robotframework = 0.4.3
 robotframework-debuglibrary = 0.3
 # Test Env
 Babel = 1.3
-Pygments = 1.6
+argh = 0.26.1
 collective.recipe.cmd = 0.11
+collective.recipe.sphinxbuilder = 0.8.2
 collective.xmltestreport = 1.3.1
+coverage = 3.7
 coveralls = 1.1
 createcoverage = 1.5
 docopt = 0.6.2
 flake8 = 2.5.2
 hexagonit.recipe.download = 1.7
+MarkupSafe = 0.23
 mccabe = 0.4.0
 mock = 1.0.1
+pathtools = 0.1.2
 plone.app.jquery = 1.11.2
+PyYAML = 3.11
 pyflakes = 1.0.0
+pygments = 1.6
 requests = 2.9.1
+sphinxcontrib-robotdoc = 0.8.0
+watchdog = 0.8.3
 zope.testrunner = 4.1.1


### PR DESCRIPTION
master has been broken on Travis for a long time. Do we still want to use this? Maybe the tests on Jenkins are enough.
But the tests on Travis are faster, and they test various browsers, so probably good to keep them.
Anyway, the biggest problem was that master depended on Plone 5 but used Plone 4.3.
And the latest plone.app.widgets release was tested, instead of master.
BTW, this contains the commit done for pull request #129.