### PR TITLE
Add navigation root support to related items widget.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,14 @@ Changelog
 
 New:
 
-- *add item here*
+- Add navigation root support to related items widget. Fix incorrect options
+  merge for TinyMCE widget.
+  [alecm]
 
 Fixes:
 
-- *add item here*
+- Ensure vocabulary lookup works on add forms for related items widget.
+  [alecm]
 
 
 2.0.3 (2016-02-14)


### PR DESCRIPTION
Fix incorrect options merge for TinyMCE widget.
Allow context url lookup to work with a wider variety of form types.