### PR TITLE
fix: Sort relateditems tree by sortable_title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Fixes:
 - Ensure we have all content for tree query in relateditems
   [Gagaro]
 
+- Sort relateditems tree by sortable_title.
+  [Gagaro]
 
 2.0.3 (2016-02-14)
 ------------------

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -140,7 +140,9 @@ def get_relateditems_options(context, value, separator, vocabulary_name,
         'treeVocabularyUrl',
         '{}/@@getVocabulary?name=plone.app.vocabularies.Catalog'.format(
             portal is not None and portal.absolute_url() or '')
-   )
+    )
+    options.setdefault('sort_on', 'sortable_title')
+    options.setdefault('sort_order', 'ascending')
 
     nav_root = getNavigationRootObject(context, get_portal())
     options['rootPath'] = (


### PR DESCRIPTION
Trees are sorted on is_folderish at the moment, but they also are filtered to only show is_folderish contents. This allow easier finding of the folder/content we want.