### PR TITLE
Fix layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Fixes:
 - Fix related items to search for the whole site rather than from the navigation root only.
   [Gagaro]
 
+- Fix Integration testing layers, their bases (the plain one and the DX one) were wrong.
+  [gforcada]
+
 
 2.0.4 (2016-02-27)
 ------------------

--- a/plone/app/widgets/testing.py
+++ b/plone/app/widgets/testing.py
@@ -120,10 +120,10 @@ class PloneAppWidgetsDXLayer(PloneAppWidgetsLayer):
 PLONEAPPWIDGETS_FIXTURE_DX = PloneAppWidgetsDXLayer()
 
 PLONEAPPWIDGETS_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(PLONEAPPWIDGETS_FIXTURE_DX,),
+    bases=(PLONEAPPWIDGETS_FIXTURE,),
     name="PloneAppWidgetsLayer:Integration")
 PLONEAPPWIDGETS_DX_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(PLONEAPPWIDGETS_FIXTURE,),
+    bases=(PLONEAPPWIDGETS_FIXTURE_DX,),
     name="PloneAppWidgetsLayer:DXIntegration")
 PLONEAPPWIDGETS_DX_ROBOT_TESTING = FunctionalTesting(
     bases=(PLONEAPPWIDGETS_FIXTURE_DX,


### PR DESCRIPTION
There are two things here:
- the integration test layers had a wrong base (the DX one had a plain base and the plain layer had a DX base, not sure how tests did not fail due to that...)
- add functional test layers so that plone.app.content can use them, related to https://github.com/plone/plone.app.content/issues/73
