### PR TITLE
fix: related items to search for the whole site rather than from the navigation root only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fix related items to search for the whole site rather than from the navigation root only.
+  [Gagaro]
 
 
 2.0.4 (2016-02-27)

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -121,7 +121,7 @@ def get_ajaxselect_options(context, value, separator, vocabulary_name,
 def get_relateditems_options(context, value, separator, vocabulary_name,
                              vocabulary_view, field_name=None):
     portal = get_portal()
-    options = get_ajaxselect_options(context, value, separator,
+    options = get_ajaxselect_options(portal, value, separator,
                                      vocabulary_name, vocabulary_view,
                                      field_name)
     if IForm.providedBy(context):
@@ -144,9 +144,12 @@ def get_relateditems_options(context, value, separator, vocabulary_name,
     options.setdefault('sort_on', 'sortable_title')
     options.setdefault('sort_order', 'ascending')
 
-    nav_root = getNavigationRootObject(context, get_portal())
-    options['rootPath'] = (
+    nav_root = getNavigationRootObject(context, portal)
+    options['basePath'] = (
         '/'.join(nav_root.getPhysicalPath()) if nav_root else '/'
+    )
+    options['rootPath'] = (
+        '/'.join(portal.getPhysicalPath()) if portal else '/'
     )
     return options
 


### PR DESCRIPTION
If the portal url is different from the navigation root one, the related item widget will not show contents outside of the navigation root.

I set vocabularyUrl as the portal url and basePath as the navigation root one to keep the current behavior but allow to find contents outside of it.