### PR TITLE
Use RAW for Archetypes TinyMCE, fixes #145.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,11 @@ Changelog
 =========
 
 1.9.1 (unreleased)
------------------
+------------------
+
+- Use the RAW text for Archetypes based TinyMCE content, this fixes
+  image handling with TinyMCE.
+  [pcdummy]
 
 - Possible to use Rich Text (TinyMCE 4, properly configured) pattern
   in Dexterity types other than plone.app.contenttypes implementation,

--- a/plone/app/widgets/at.py
+++ b/plone/app/widgets/at.py
@@ -578,7 +578,7 @@ class TinyMCEWidget(BaseWidget):
         charset = properties.site_properties.getProperty('default_charset',
                                                          'utf-8')
         args['value'] = (request.get(field.getName(),
-                                     field.getAccessor(context)())
+                                     field.getRaw(context))
                          ).decode(charset)
 
         args.setdefault('pattern_options', {})


### PR DESCRIPTION
Use the RAW text for Archetypes based TinyMCE content, this fixes image handling with TinyMCE.

Signed-off-by: Rene Jochum <rene@jochums.at>