### PR TITLE
fix ajaxselectwidget value on form validation errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
+- Fix value for at.AjaxSelectWidget when the edit form returns with
+  validation errors
+  [petschki]
+
 - Use the RAW text for Archetypes based TinyMCE content, this fixes
   image handling with TinyMCE.
   [pcdummy]

--- a/plone/app/widgets/at.py
+++ b/plone/app/widgets/at.py
@@ -361,7 +361,7 @@ class AjaxSelectWidget(BaseWidget):
         args['name'] = field.getName()
         value = request.get(field.getName(), field.getAccessor(context)())
         if isinstance(value, basestring):
-            value = value.split(self.separator)
+            value = value.strip().split(self.separator)
         args['value'] = self.separator.join(value)
 
         args.setdefault('pattern_options', {})

--- a/plone/app/widgets/at.py
+++ b/plone/app/widgets/at.py
@@ -359,8 +359,10 @@ class AjaxSelectWidget(BaseWidget):
             self.vocabulary = vocabulary_factory
 
         args['name'] = field.getName()
-        args['value'] = self.separator.join(request.get(
-            field.getName(), field.getAccessor(context)()))
+        value = request.get(field.getName(), field.getAccessor(context)())
+        if isinstance(value, basestring):
+            value = value.split(self.separator)
+        args['value'] = self.separator.join(value)
 
         args.setdefault('pattern_options', {})
         args['pattern_options'] = dict_merge(


### PR DESCRIPTION
please see #111 ...
this should obsolete #112 which is quite dirty ... @jensens ?
also someone should check https://github.com/plone/Products.Archetypes/blob/master/Products/Archetypes/Widget.py#L1213 for similar problem