### PR TITLE
Take more time during robot tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Take more time during robot tests.
+  I hope that this makes a sometimes failing test always pass.  [maurits]
 
 
 2.0.6 (2016-08-18)

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -15,13 +15,15 @@ Querystring Widget rows appear and disappear correctly
     And I create a collection  My Collection
         Wait For Condition  return $('body.patterns-loaded').size() > 0
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1)
-        Page should not contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Sleep  1
+        Page should not contain Element   css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When I select criteria index in row  1  Expiration date
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2) .querystring-criteria-remove
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1) .querystring-criteria-remove
-        Page should not contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Sleep  1
+        Page should not contain Element   css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
 
 
 *** Comment out until we can figure out what is wrong with this test... ***


### PR DESCRIPTION
I hope that this makes a sometimes failing test always pass.

Note: we should run the Jenkins tests at least twice before merging.