### PR TITLE
Fix RelatedItemsWidget calling self.items for Plone > 4.3.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix RelatedItemsWidget calling self.items, which was turned back into a
+  property in z3c.form 3.2.11. (Used in Plone > 4.3.11) [fredvd]
 
 
 1.9.1 (2017-02-12)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,3 +40,5 @@ scripts =
 [versions]
 # use latest version of coverage
 coverage =
+# plone.app.widgets is pinned in plone's versions.cfg
+plone.app.widgets = 

--- a/plone/app/widgets/dx.py
+++ b/plone/app/widgets/dx.py
@@ -612,7 +612,10 @@ class SelectWidget(BaseWidget, z3cform_SelectWidget):
             options['allowClear'] = True
 
         items = []
-        for item in self.items():
+        fetchitems = self.items
+        if callable(fetchitems):
+            fetchitems = fetchitems()
+        for item in fetchitems:
             if not isinstance(item['content'], basestring):
                 item['content'] = translate(
                     item['content'],


### PR DESCRIPTION
self.items was changed back into a property in z3c.form 3.2.11