### PR TITLE
Related items widget options changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,13 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Related items widget options changes:
+  - Let the browsing/searching start path be the current context if its folderish or a level up.
+  - Include the ``contextPath`` option to exclude the current context from selection.
+  - Include the ``favorites`` option with the current context and the navigation root to quickly jump to these paths.
+  - Clean up obsolete options.
+    Fixes https://github.com/plone/Products.CMFPlone/issues/1974
+    [thet]
 
 Bug fixes:
 

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -1,11 +1,11 @@
 from mock import Mock
 from mock import patch
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
+from plone.app.widgets.utils import get_relateditems_options
 
-try:
-    import unittest2 as unittest
-except ImportError:  # pragma: nocover
-    import unittest  # pragma: nocover
-    assert unittest  # pragma: nocover
+import unittest
 
 
 class MockTool(Mock):
@@ -47,3 +47,230 @@ class UtilsTests(unittest.TestCase):
         # restore original state
         utils.HAS_PAE = orig_HAS_PAE
         reload(utils)
+
+
+class TestRelatedItemsOptions(unittest.TestCase):
+    layer = PLONEAPPWIDGETS_INTEGRATION_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
+
+    def test__base_relateditems_options(self):
+        """Test related items options on root:
+        All URLs and paths equal root url and path,
+        no favorites
+        """
+
+        portal = self.layer['portal']
+        options = get_relateditems_options(
+            portal,
+            None,
+            '#!@',
+            'test_vocab',
+            '@@vocab',
+            'testfield'
+        )
+
+        # vocab is correctly set
+        self.assertTrue(
+            '@@vocab?name=test_vocab&field=testfield'
+            in options['vocabularyUrl']
+        )
+
+        # rootUrl contains something
+        self.assertTrue(
+            bool(options['rootUrl'])
+        )
+
+        root_path = context_path = '/'.join(portal.getPhysicalPath())
+        root_url = context_url = portal.absolute_url()
+
+        # context_path contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_path))
+        # context_url contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_url))
+
+        self.assertEquals(
+            options['rootUrl'],
+            root_url
+        )
+
+        self.assertEquals(
+            options['rootPath'],
+            root_path
+        )
+
+        self.assertEquals(
+            options['vocabularyUrl'],
+            root_url + '/@@vocab?name=test_vocab&field=testfield'
+        )
+
+        self.assertEquals(
+            options['basePath'],
+            context_path
+        )
+
+        self.assertEquals(
+            options['contextPath'],
+            context_path
+        )
+
+        self.assertEquals(
+            options['separator'],
+            '#!@'
+        )
+
+        self.assertTrue(
+            'favorites' not in options
+        )
+
+    def test__subfolder_relateditems_options(self):
+        """Test related items options on subfolder:
+        Vocab called on root, start path is folder, have favorites.
+        """
+
+        portal = self.layer['portal']
+        portal.invokeFactory('Folder', 'sub')
+        sub = portal.sub
+        options = get_relateditems_options(
+            sub,
+            None,
+            '#!@',
+            'test_vocab',
+            '@@vocab',
+            'testfield'
+        )
+
+        # vocab is correctly set
+        self.assertTrue(
+            '@@vocab?name=test_vocab&field=testfield'
+            in options['vocabularyUrl']
+        )
+
+        # rootUrl contains something
+        self.assertTrue(
+            bool(options['rootUrl'])
+        )
+
+        root_path = '/'.join(portal.getPhysicalPath())
+        root_url = portal.absolute_url()
+        context_path = '/'.join(sub.getPhysicalPath())
+        context_url = sub.absolute_url()
+
+        # context_path contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_path))
+        # context_url contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_url))
+
+        self.assertEquals(
+            options['rootUrl'],
+            root_url
+        )
+
+        self.assertEquals(
+            options['rootPath'],
+            root_path
+        )
+
+        self.assertEquals(
+            options['vocabularyUrl'],
+            root_url + '/@@vocab?name=test_vocab&field=testfield'
+        )
+
+        self.assertEquals(
+            options['basePath'],
+            context_path
+        )
+
+        self.assertEquals(
+            options['contextPath'],
+            context_path
+        )
+
+        self.assertEquals(
+            options['separator'],
+            '#!@'
+        )
+
+        self.assertEquals(
+            len(options['favorites']),
+            2
+        )
+
+        self.assertEquals(
+            sorted(options['favorites'][0].keys()),
+            ['path', 'title']
+        )
+
+    def test__subdocument_relateditems_options(self):
+        """Test related items options on subdoc:
+        Vocab called on root, start path is root as document is not folderish,
+        no favorites.
+        """
+
+        portal = self.layer['portal']
+        portal.invokeFactory('Document', 'sub')
+        sub = portal.sub
+        options = get_relateditems_options(
+            sub,
+            None,
+            '#!@',
+            'test_vocab',
+            '@@vocab',
+            'testfield'
+        )
+
+        # vocab is correctly set
+        self.assertTrue(
+            '@@vocab?name=test_vocab&field=testfield'
+            in options['vocabularyUrl']
+        )
+
+        # rootUrl contains something
+        self.assertTrue(
+            bool(options['rootUrl'])
+        )
+
+        root_path = '/'.join(portal.getPhysicalPath())
+        root_url = portal.absolute_url()
+        context_path = '/'.join(sub.getPhysicalPath())
+        context_url = sub.absolute_url()
+
+        # context_path contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_path))
+        # context_url contains something, otherwise this test is meaningless
+        self.assertTrue(bool(context_url))
+
+        self.assertEquals(
+            options['rootUrl'],
+            root_url
+        )
+
+        self.assertEquals(
+            options['rootPath'],
+            root_path
+        )
+
+        self.assertEquals(
+            options['vocabularyUrl'],
+            root_url + '/@@vocab?name=test_vocab&field=testfield'
+        )
+
+        self.assertEquals(
+            options['basePath'],
+            root_path
+        )
+
+        self.assertEquals(
+            options['contextPath'],
+            context_path
+        )
+
+        self.assertEquals(
+            options['separator'],
+            '#!@'
+        )
+
+        self.assertTrue(
+            'favorites' not in options
+        )


### PR DESCRIPTION
- Let the browsing/searching start path be the current context if its folderish or a level up.
- Include the ``contextPath`` option to exclude the current context from selection.
- Include the ``favorites`` option with the current context and the navigation root to quickly jump to these paths.
- Clean up obsolete options.
Fixes https://github.com/plone/Products.CMFPlone/issues/1974