### PR TITLE
fix tinymce options with non-contentish contexts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,9 @@ New features:
     [thet]
 
 Bug fixes:
-
-- *add item here*
+    
+- Change deprecated unittest method ``assertEquals`` to ``assertEqual``.
+  [thet]
 
 
 2.1 (2017-02-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,11 @@ New features:
     [thet]
 
 Bug fixes:
-    
+
+- Fix broken ``get_tinymce_options`` when called with non-contentish contexts like form or field contexts.
+  Refs: https://github.com/plone/plone.app.widgets/pull/160 
+  [thet]
+
 - Change deprecated unittest method ``assertEquals`` to ``assertEqual``.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,10 +20,6 @@ New features:
 
 Bug fixes:
 
-- Fix broken ``get_tinymce_options`` when called with non-contentish contexts like form or field contexts.
-  Refs: https://github.com/plone/plone.app.widgets/pull/160 
-  [thet]
-
 - Change deprecated unittest method ``assertEquals`` to ``assertEqual``.
   [thet]
 

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -4,6 +4,8 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
 from plone.app.widgets.utils import get_relateditems_options
+from plone.app.widgets.utils import get_tinymce_options
+from z3c.form.form import Form
 
 import unittest
 
@@ -274,3 +276,36 @@ class TestRelatedItemsOptions(unittest.TestCase):
         self.assertTrue(
             'favorites' not in options
         )
+
+
+class TestTinyMCEOptions(unittest.TestCase):
+    layer = PLONEAPPWIDGETS_INTEGRATION_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
+
+    def test__tinymce_options_different_contexts(self):
+        """Test if ``get_tinymce_options`` can be called with different
+        contexts, including invalid and form contexts.
+        """
+        request = self.layer['request']
+        portal = self.layer['portal']
+        portal.invokeFactory('Folder', 'sub')
+        sub = portal.sub
+        form = Form(sub, request)
+
+        # TinyMCE on portal context
+        options = get_tinymce_options(portal, None, request)
+        self.assertEqual(options['relatedItems']['basePath'], '/plone')
+
+        # TinyMCE on sub folder context
+        options = get_tinymce_options(sub, None, request)
+        self.assertEqual(options['relatedItems']['basePath'], '/plone/sub')
+
+        # TinyMCE on a Form context
+        options = get_tinymce_options(form, None, request)
+        self.assertEqual(options['relatedItems']['basePath'], '/plone/sub')
+
+        # TinyMCE on no / non-itemish context
+        options = get_tinymce_options(None, None, request)
+        self.assertEqual(options['relatedItems']['basePath'], '/plone')

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -5,7 +5,6 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
 from plone.app.widgets.utils import get_relateditems_options
 from plone.app.widgets.utils import get_tinymce_options
-from z3c.form.form import Form
 
 import unittest
 
@@ -292,7 +291,6 @@ class TestTinyMCEOptions(unittest.TestCase):
         portal = self.layer['portal']
         portal.invokeFactory('Folder', 'sub')
         sub = portal.sub
-        form = Form(sub, request)
 
         # TinyMCE on portal context
         options = get_tinymce_options(portal, None, request)
@@ -301,11 +299,3 @@ class TestTinyMCEOptions(unittest.TestCase):
         # TinyMCE on sub folder context
         options = get_tinymce_options(sub, None, request)
         self.assertEqual(options['relatedItems']['basePath'], '/plone/sub')
-
-        # TinyMCE on a Form context
-        options = get_tinymce_options(form, None, request)
-        self.assertEqual(options['relatedItems']['basePath'], '/plone/sub')
-
-        # TinyMCE on no / non-itemish context
-        options = get_tinymce_options(None, None, request)
-        self.assertEqual(options['relatedItems']['basePath'], '/plone')

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -34,15 +34,15 @@ class UtilsTests(unittest.TestCase):
                            # works, even if it was imported before.,,
             orig_HAS_PAE = utils.HAS_PAE
             utils.HAS_PAE = True
-            self.assertEquals(utils.first_weekday(), 0)
+            self.assertEqual(utils.first_weekday(), 0)
             base.first_weekday = lambda: 1
-            self.assertEquals(utils.first_weekday(), 1)
+            self.assertEqual(utils.first_weekday(), 1)
             base.first_weekday = lambda: 5
-            self.assertEquals(utils.first_weekday(), 1)
+            self.assertEqual(utils.first_weekday(), 1)
 
             # test without plone.app.event installed
             utils.HAS_PAE = False
-            self.assertEquals(utils.first_weekday(), 0)
+            self.assertEqual(utils.first_weekday(), 0)
 
         # restore original state
         utils.HAS_PAE = orig_HAS_PAE
@@ -90,32 +90,32 @@ class TestRelatedItemsOptions(unittest.TestCase):
         # context_url contains something, otherwise this test is meaningless
         self.assertTrue(bool(context_url))
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootUrl'],
             root_url
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootPath'],
             root_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['vocabularyUrl'],
             root_url + '/@@vocab?name=test_vocab&field=testfield'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['basePath'],
             context_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['contextPath'],
             context_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['separator'],
             '#!@'
         )
@@ -162,42 +162,42 @@ class TestRelatedItemsOptions(unittest.TestCase):
         # context_url contains something, otherwise this test is meaningless
         self.assertTrue(bool(context_url))
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootUrl'],
             root_url
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootPath'],
             root_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['vocabularyUrl'],
             root_url + '/@@vocab?name=test_vocab&field=testfield'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['basePath'],
             context_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['contextPath'],
             context_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['separator'],
             '#!@'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(options['favorites']),
             2
         )
 
-        self.assertEquals(
+        self.assertEqual(
             sorted(options['favorites'][0].keys()),
             ['path', 'title']
         )
@@ -241,32 +241,32 @@ class TestRelatedItemsOptions(unittest.TestCase):
         # context_url contains something, otherwise this test is meaningless
         self.assertTrue(bool(context_url))
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootUrl'],
             root_url
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['rootPath'],
             root_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['vocabularyUrl'],
             root_url + '/@@vocab?name=test_vocab&field=testfield'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['basePath'],
             root_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['contextPath'],
             context_path
         )
 
-        self.assertEquals(
+        self.assertEqual(
             options['separator'],
             '#!@'
         )

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -4,6 +4,7 @@ from Acquisition import aq_base
 from Acquisition import aq_parent
 from datetime import datetime
 from OFS.interfaces import IFolder
+from OFS.interfaces import ISimpleItem
 from plone.app.layout.navigation.root import getNavigationRootObject
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.utils import getToolByName
@@ -194,6 +195,12 @@ def get_tinymce_options(context, field, request):
     """
     options = {}
     try:
+
+        if IForm.providedBy(context):
+            context = context.context
+        elif not ISimpleItem.providedBy(context):
+            context = getSite()
+
         pattern_options = getMultiAdapter(
             (context, request, field),
             name="plone_settings").tinymce()['data-pat-tinymce']

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -195,12 +195,6 @@ def get_tinymce_options(context, field, request):
     """
     options = {}
     try:
-
-        if IForm.providedBy(context):
-            context = context.context
-        elif not ISimpleItem.providedBy(context):
-            context = getSite()
-
         pattern_options = getMultiAdapter(
             (context, request, field),
             name="plone_settings").tinymce()['data-pat-tinymce']


### PR DESCRIPTION
Fix broken get_tinymce_options when called with non-contentish contexts like form or field contexts.

Fixes: https://github.com/collective/collective.easyform/issues/67