### PR TITLE
Unset and reset ``define`` and ``require``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Changelog
   They are merged with the ``at`` respectively ``dx`` modules.
   [thet]
 
+- Unset and reset ``define`` and ``require`` before and after the plone.app.widgets JavaScript bundle.
+  This avoids the infamous ``Mismatched anonymous define`` error with unbundled JavaScript supporting RequireJS.
+  See: http://requirejs.org/docs/errors.html#mismatch
+  [thet]
+
 - Remove Plone 5 specific zcml conditions
   [petschki]
 

--- a/plone/app/widgets/configure.zcml
+++ b/plone/app/widgets/configure.zcml
@@ -301,4 +301,13 @@
       purge="False"
       run_deps="False" />
 
+  <genericsetup:upgradeStep
+      title="Unset / Reset RequireJS"
+      description="Integrate Scripts to unset and reset RequireJS."
+      source="2"
+      destination="3"
+      handler="plone.app.widgets.upgrades.upgrade_2_to_3"
+      profile="plone.app.widgets:default"
+      />
+
 </configure>

--- a/plone/app/widgets/configure.zcml
+++ b/plone/app/widgets/configure.zcml
@@ -16,6 +16,17 @@
   <include package=".browser" />
 
   <browser:resource
+      name="plone.app.widgets-requirejs-unset.js"
+      file="static/requirejs-unset.js"
+      layer=".interfaces.IWidgetsLayer"
+      />
+  <browser:resource
+      name="plone.app.widgets-requirejs-reset.js"
+      file="static/requirejs-reset.js"
+      layer=".interfaces.IWidgetsLayer"
+      />
+
+  <browser:resource
       name="plone.app.widgets-bootstrap-glyphicons-halflings-regular.eot"
       file="static/widgets-bootstrap-glyphicons-halflings-regular.eot"
       layer=".interfaces.IWidgetsLayer"

--- a/plone/app/widgets/profiles/default/jsregistry.xml
+++ b/plone/app/widgets/profiles/default/jsregistry.xml
@@ -25,4 +25,24 @@
         inline="False"
         />
 
+    <javascript
+        id="++resource++plone.app.widgets-requirejs-unset.js"
+        insert-before="++resource++plone.app.widgets.js"
+        cacheable="True"
+        compression="safe"
+        cookable="True"
+        enabled="True"
+        inline="False"
+        />
+
+    <javascript
+        id="++resource++plone.app.widgets-requirejs-reset.js"
+        insert-after="++resource++plone.app.widgets.js"
+        cacheable="True"
+        compression="safe"
+        cookable="True"
+        enabled="True"
+        inline="False"
+        />
+
 </object>

--- a/plone/app/widgets/profiles/default/metadata.xml
+++ b/plone/app/widgets/profiles/default/metadata.xml
@@ -1,5 +1,3 @@
 <metadata>
-    <version>2</version>
-    <dependencies>
-    </dependencies>
+    <version>3</version>
 </metadata>

--- a/plone/app/widgets/profiles/uninstall/jsregistry.xml
+++ b/plone/app/widgets/profiles/uninstall/jsregistry.xml
@@ -15,9 +15,19 @@
     <javascript bundle="default" id="tiny_mce_gzip.js" />
     <javascript bundle="default" id="toc.js" />
 
-    <javascript remove="True"
+    <javascript
+        remove="True"
         id="++resource++plone.app.widgets.js"
         />
 
-</object>
+    <javascript
+        remove="True"
+        id="++resource++plone.app.widgets-requirejs-unset.js"
+        />
 
+    <javascript
+        remove="True"
+        id="++resource++plone.app.widgets-requirejs-reset.js"
+        />
+
+</object>

--- a/plone/app/widgets/static/requirejs-reset.js
+++ b/plone/app/widgets/static/requirejs-reset.js
@@ -1,0 +1,2 @@
+var define = _old_define;
+var require = _old_require;

--- a/plone/app/widgets/static/requirejs-unset.js
+++ b/plone/app/widgets/static/requirejs-unset.js
@@ -1,0 +1,4 @@
+var _old_define = define;
+var _old_require = require;
+define = undefined;
+require = undefined;

--- a/plone/app/widgets/upgrades.py
+++ b/plone/app/widgets/upgrades.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore.utils import getToolByName
+
+
+PROFILE_ID = 'profile-plone.app.widgets:default'
+
+
+def upgrade_2_to_3(context):
+    """Remove JS and CSS resources from portal_css and portal_js registry.
+    Import resource registry configuration.
+    """
+    setup = getToolByName(context, "portal_setup")
+    setup.runImportStepFromProfile(PROFILE_ID, 'jsregistry')
+    tool = getToolByName(context, 'portal_javascripts')
+    tool.cookResources()


### PR DESCRIPTION
Unset and reset ``define`` and ``require`` before and after the plone.app.widgets JavaScript bundle.
This avoids the infamous ``Mismatched anonymous define`` error with unbundled JavaScript supporting RequireJS.
See: http://requirejs.org/docs/errors.html#mismatch