### PR TITLE
Failsafe requirejs unset/reset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.10 (unreleased)
 -----------------
 
+- failsafe Unset and reset ``define`` and ``require``
+  [petschki]
+
 - PEP 8.
   [thet]
 

--- a/plone/app/widgets/static/requirejs-reset.js
+++ b/plone/app/widgets/static/requirejs-reset.js
@@ -1,2 +1,2 @@
-var define = _old_define;
-var require = _old_require;
+if(typeof _old_define !== 'undefined') { var define = _old_define; }
+if(typeof _old_require !== 'undefined') { var require = _old_require; }

--- a/plone/app/widgets/static/requirejs-unset.js
+++ b/plone/app/widgets/static/requirejs-unset.js
@@ -1,4 +1,4 @@
-var _old_define = define;
-var _old_require = require;
+if(typeof define !== 'undefined') { var _old_define = define; }
+if(typeof require !== 'undefined') { var _old_require = require; }
 define = undefined;
 require = undefined;


### PR DESCRIPTION
Introduced in 5c75aa8d2a1637b80b461200afd5b2b51fd74f88 it might happen,
that there is no `define` or `require` defined. handle this gracefully.