### PR TITLE
QueryString widget: parameters for subwidgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Pass parameter of subwidgets to the query string widget to get them properly initialized.
+  Fixes a problem where the related items widget behaved differently from other areas and the date widget didn't respect the users localization.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -3,6 +3,7 @@ from mock import patch
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
+from plone.app.widgets.utils import get_querystring_options
 from plone.app.widgets.utils import get_relateditems_options
 from plone.app.widgets.utils import get_tinymce_options
 
@@ -48,6 +49,59 @@ class UtilsTests(unittest.TestCase):
         # restore original state
         utils.HAS_PAE = orig_HAS_PAE
         reload(utils)
+
+
+class TestQueryStringOptions(unittest.TestCase):
+    layer = PLONEAPPWIDGETS_INTEGRATION_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
+
+    def test__query_string_options(self):
+        """Test query string options on root:
+        All URLs and paths equal root url and path,
+        no favorites
+        """
+
+        portal = self.layer['portal']
+        options = get_querystring_options(
+            portal,
+            '@@qsOptions'
+        )
+
+        # Test base options
+        self.assertEqual(
+            options['indexOptionsUrl'],
+            'http://nohost/plone/@@qsOptions'
+        )
+
+        self.assertEqual(
+            options['previewCountURL'],
+            'http://nohost/plone/@@querybuildernumberofresults'
+        )
+
+        self.assertEqual(
+            options['previewURL'],
+            'http://nohost/plone/@@querybuilder_html_results'
+        )
+
+        # Test options of the AJAX select widget
+        self.assertEqual(
+            options['patternAjaxSelectOptions']['separator'],
+            ';'
+        )
+
+        # Test options of the date picker
+        self.assertEqual(
+            options['patternDateOptions']['time'],
+            False
+        )
+
+        # Test options of the related items widget
+        self.assertEqual(
+            options['patternRelateditemsOptions']['basePath'],
+            '/plone'
+        )
 
 
 class TestRelatedItemsOptions(unittest.TestCase):

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -186,7 +186,24 @@ def get_querystring_options(context, querystring_view):
     return {
         'indexOptionsUrl': '{}/{}'.format(portal_url, querystring_view),
         'previewURL': '%s/@@querybuilder_html_results' % base_url,
-        'previewCountURL': '%s/@@querybuildernumberofresults' % base_url
+        'previewCountURL': '%s/@@querybuildernumberofresults' % base_url,
+        'patternDateOptions': get_date_options(getRequest()),
+        'patternAjaxSelectOptions': get_ajaxselect_options(
+            context,
+            None,
+            ';',
+            None,
+            None,
+            None
+        ),
+        'patternRelateditemsOptions': get_relateditems_options(
+            context,
+            None,
+            ';',
+            'plone.app.vocabularies.Catalog',
+            '@@getVocabulary',
+            'relatedItems'
+        )
     }
 
 


### PR DESCRIPTION
Pass parameter of subwidgets to the query string widget to get them properly initialized.
Fixes a problem where the related items widget behaved differently from other areas and the date widget didn't respect the users localization.