### PR TITLE
Related items widget: show a recently used dropdown.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Related items widget: show a recently used dropdown, but do not activate it.
+  plone.app.relationfield itself is activating the "recently used" feature.
+  The "recently used" dropdown is only available for Mockup 2.6.3+.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -102,6 +102,9 @@ class TestQueryStringOptions(unittest.TestCase):
             options['patternRelateditemsOptions']['basePath'],
             '/plone'
         )
+        self.assertTrue(
+            'recentlyUsed' not in options['patternRelateditemsOptions']
+        )
 
 
 class TestRelatedItemsOptions(unittest.TestCase):
@@ -177,6 +180,16 @@ class TestRelatedItemsOptions(unittest.TestCase):
 
         self.assertTrue(
             'favorites' not in options
+        )
+
+        # Recently used is configured, but off per default.
+        self.assertEqual(
+            options['recentlyUsed'],
+            False
+        )
+        self.assertEqual(
+            options['recentlyUsedKey'],
+            'relateditems_recentlyused_testfield_' + TEST_USER_ID
         )
 
     def test__subfolder_relateditems_options(self):

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -124,7 +124,8 @@ def get_ajaxselect_options(context, value, separator, vocabulary_name,
 
 
 def get_relateditems_options(context, value, separator, vocabulary_name,
-                             vocabulary_view, field_name=None):
+                             vocabulary_view, field_name=None,
+                             include_recently_added=True):
 
     if IForm.providedBy(context):
         context = context.context
@@ -174,6 +175,16 @@ def get_relateditems_options(context, value, separator, vocabulary_name,
             }
         ]
 
+    if include_recently_added:
+        # Options for recently used key
+        tool = getToolByName(context, 'portal_membership')
+        user = tool.getAuthenticatedMember()
+        options['recentlyUsed'] = False  # Keep that off in Plone 5.1
+        options['recentlyUsedKey'] = (u'relateditems_recentlyused_%s_%s' % (
+            field_name or '',
+            user.id
+        ))  # use string substitution with %s here for automatic str casting.
+
     return options
 
 
@@ -202,7 +213,8 @@ def get_querystring_options(context, querystring_view):
             ';',
             'plone.app.vocabularies.Catalog',
             '@@getVocabulary',
-            'relatedItems'
+            'relatedItems',
+            include_recently_added=False
         )
     }
 


### PR DESCRIPTION
Needs mockup 2.6.3 for that to work.

@jensens this one obsoletes https://github.com/plone/plone.app.relationfield/pull/21

I like it better to have the "recently used" pattern options managed here. This way, it uses the current field name for any instance of the related items widget. The downside is, the "recently used" feature is enabled per default for all instances of the related item widget (except those in the query string pattern).

I'd got for this one.