### PR TITLE
Marked unstable robotframework test as noncritical.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Marked unstable robotframework test as noncritical.
+  And maybe fix it by using keyword ``Wait Until Page Does Not Contain Element``.
+  [maurits]
 
 
 2.2.2 (2017-09-05)

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -11,19 +11,18 @@ ${querywidget_selector}  \#formfield-form-widgets-ICollection-query
 *** Test Cases ***
 
 Querystring Widget rows appear and disappear correctly
+  [Tags]  unstable
   Given I'm logged in as a 'Site Administrator'
     And I create a collection  My Collection
         Wait For Condition  return $('body.patterns-loaded').size() > 0
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1)
-        Sleep  1
-        Page should not contain Element   css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Wait Until Page Does Not Contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When I select criteria index in row  1  Expiration date
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2) .querystring-criteria-remove
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When Click Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1) .querystring-criteria-remove
-        Sleep  1
-        Page should not contain Element   css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
+        Wait Until Page Does Not Contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
 
 
 *** Comment out until we can figure out what is wrong with this test... ***

--- a/plone/app/widgets/tests/test_robot.py
+++ b/plone/app/widgets/tests/test_robot.py
@@ -18,7 +18,8 @@ def test_suite():
         doc.startswith('test_')
     ]
     for robot_test in robot_tests:
-        robottestsuite = robotsuite.RobotTestSuite(robot_test)
+        robottestsuite = robotsuite.RobotTestSuite(
+            robot_test, noncritical=['unstable'])
         robottestsuite.level = ROBOT_TEST_LEVEL
         suite.addTests([
             layered(robottestsuite,


### PR DESCRIPTION
And maybe fix it by using keyword `Wait Until Page Does Not Contain Element`.