### PR TITLE
get relatedItems options for tinyMCE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.12 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- read relatedItems options for TinyMCE modals. This enables favorites/recent added menu
+  within TinyMCE image/link modal dialog.
+  [petschki]
 
 
 1.11 (2018-10-29)

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -460,6 +460,14 @@ def get_tinymce_options(context, field, request):
         'anchorSelector': utility.anchor_selector,
         'linkableTypes': utility.linkable.split('\n')
     }
+    options['relatedItems'] = get_relateditems_options(
+        context,
+        None,
+        ';',
+        'plone.app.vocabularies.Catalog',
+        '@@getVocabulary',
+        'relatedItems',
+    )
     return options
 
 


### PR DESCRIPTION
enable relatedItems options (favorites/recently added menu) for TinyMCE modal dialog.