### PR TITLE
get_ajaxselect_options is no longer used in plone.app.z3cform

### DIFF
--- a/news/194.breaking
+++ b/news/194.breaking
@@ -1,0 +1,7 @@
+Deprecate ``get_ajaxselect_options`` (no longer used).
+``IWidgetsLayer`` and ``IWidgetsView`` are no longer used, remove them.
+Deprecated ``IFileFactory`` import, use ``zope.filerepresentation`` instead.
+Hard depend on ``plone.app.event``, it is meanwhile a dependenciy of Plone core.
+Move ``IFieldPermissionChecker`` and ``Zope2FileUploadStorable`` to ``plone.app.z3cform`` in order to slowly fade out this package.
+Use util ``first_weekday`` from ``plone.app.event`` and do not duplicate here; deprecated import placed.
+[jensens]

--- a/plone/app/widgets/configure.zcml
+++ b/plone/app/widgets/configure.zcml
@@ -8,10 +8,4 @@
 
   <include package="mockup" />
 
-  <utility
-    name="ZPublisher.HTTPRequest.FileUpload"
-    provides="plone.namedfile.interfaces.IStorage"
-    factory=".factories.Zope2FileUploadStorable"
-    />
-
 </configure>

--- a/plone/app/widgets/factories.py
+++ b/plone/app/widgets/factories.py
@@ -5,5 +5,5 @@ import zope.deferredimport
 zope.deferredimport.initialize()
 zope.deferredimport.deprecated(
     'Import Zope2FileUploadStorable from plone.app.z3cform.factories instead',
-    Zope2FileUploadStorable='plone.app.z3cform:factories.Zope2FileUploadStorable',
+    Zope2FileUploadStorable='plone.app.z3cform.factories:Zope2FileUploadStorable',
 )

--- a/plone/app/widgets/factories.py
+++ b/plone/app/widgets/factories.py
@@ -1,17 +1,9 @@
-from zope.interface import implementer
-from plone.namedfile.storages import MAXCHUNKSIZE
-from plone.namedfile.interfaces import IStorage
+# -*- coding: utf-8 -*-
+import zope.deferredimport
 
-
-@implementer(IStorage)
-class Zope2FileUploadStorable(object):
-
-    def store(self, data, blob):
-        data.seek(0)
-
-        fp = blob.open('w')
-        block = data.read(MAXCHUNKSIZE)
-        while block:
-            fp.write(block)
-            block = data.read(MAXCHUNKSIZE)
-        fp.close()
+# can be removed in Plone 6
+zope.deferredimport.initialize()
+zope.deferredimport.deprecated(
+    'Import Zope2FileUploadStorable from plone.app.z3cform.factories instead',
+    Zope2FileUploadStorable='plone.app.z3cform:factories.Zope2FileUploadStorable',
+)

--- a/plone/app/widgets/interfaces.py
+++ b/plone/app/widgets/interfaces.py
@@ -1,15 +1,18 @@
 from zope.interface import Interface
 from plone.app.z3cform.interfaces import IPloneFormLayer
-from zope.filerepresentation.interfaces import IFileFactory
 
 
 class IWidgetsLayer(IPloneFormLayer):
     """Browser layer used to indicate that plone.app.widgets is installed
+
+    DEPRECATED
     """
 
 
 class IWidgetsView(Interface):
     """A view that gives access to various widget related functions.
+
+    DEPRECATED
     """
 
     def getVocabulary():

--- a/plone/app/widgets/interfaces.py
+++ b/plone/app/widgets/interfaces.py
@@ -5,10 +5,10 @@ import zope.deferredimport
 zope.deferredimport.initialize()
 zope.deferredimport.deprecated(
     'Import IFileFactory from zope.filerepresentation.interfaces instead',
-    IFileFactory='zope.filerepresentation:interfaces.IFileFactory',
+    IFileFactory='zope.filerepresentation.interfaces:IFileFactory',
 )
 
 zope.deferredimport.deprecated(
     'Import IFieldPermissionChecker from plone.app.z3cform.interfaces instead',
-    IFieldPermissionChecker='plone.app.z3cform:interfaces.IFieldPermissionChecker',  # noqa
+    IFieldPermissionChecker='plone.app.z3cform.interfaces:IFieldPermissionChecker',  # noqa
 )

--- a/plone/app/widgets/interfaces.py
+++ b/plone/app/widgets/interfaces.py
@@ -1,27 +1,13 @@
+# -*- coding: utf-8 -*-
 from zope.interface import Interface
-from plone.app.z3cform.interfaces import IPloneFormLayer
 
+import zope.deferredimport
 
-class IWidgetsLayer(IPloneFormLayer):
-    """Browser layer used to indicate that plone.app.widgets is installed
-
-    DEPRECATED
-    """
-
-
-class IWidgetsView(Interface):
-    """A view that gives access to various widget related functions.
-
-    DEPRECATED
-    """
-
-    def getVocabulary():
-        """Returns vocabulary
-        """
-
-    def bodyDataOptions():
-        """Returns the data attributes to be used on the body tag.
-        """
+zope.deferredimport.initialize()
+zope.deferredimport.deprecated(
+    'Import from new.baz.baaz instead',
+    IFileFactory='zope.filerepresentation:interfaces.IFileFactory',
+)
 
 
 class IFieldPermissionChecker(Interface):

--- a/plone/app/widgets/interfaces.py
+++ b/plone/app/widgets/interfaces.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
-from zope.interface import Interface
-
 import zope.deferredimport
 
+# FileFactory only needed by ATContentTypes
 zope.deferredimport.initialize()
 zope.deferredimport.deprecated(
-    'Import from new.baz.baaz instead',
+    'Import IFileFactory from zope.filerepresentation.interfaces instead',
     IFileFactory='zope.filerepresentation:interfaces.IFileFactory',
 )
 
-
-class IFieldPermissionChecker(Interface):
-    """Adapter factory for checking whether a user has permission to
-    edit a specific field on a content object.
-    """
-
-    def validate(field_name, vocabulary_name=None):
-        """Returns True if the current user has permission to edit the
-        `field_name` field.  Returns False if the user does not have
-        permission.  Raises and AttributeError if the field cannot be
-        found.
-        """
+zope.deferredimport.deprecated(
+    'Import IFieldPermissionChecker from plone.app.z3cform.interfaces instead',
+    IFieldPermissionChecker='plone.app.z3cform:interfaces.IFieldPermissionChecker',  # noqa
+)

--- a/plone/app/widgets/tests/test_utils.py
+++ b/plone/app/widgets/tests/test_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from mock import Mock
 from mock import patch
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -7,51 +6,8 @@ from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
 from plone.app.widgets.utils import get_querystring_options
 from plone.app.widgets.utils import get_relateditems_options
 from plone.app.widgets.utils import get_tinymce_options
-from six.moves import reload_module
 
 import unittest
-
-
-class MockTool(Mock):
-    firstweekday = 6
-
-
-class UtilsTests(unittest.TestCase):
-
-    def test__first_weekday(self):
-        # make sure, plone.app.event is available and mock it.
-        mock = Mock()
-        modules = {
-            'plone': mock,
-            'plone.app': mock.module,
-            'plone.app.event': mock.module.module,
-            'plone.app.event.base': mock.module.module.module,
-        }
-        with patch('Products.CMFCore.utils.getToolByName', new=MockTool), \
-                patch.dict('sys.modules', modules):
-            # test for plone.app.event installed
-            from plone.app.event import base
-            base.first_weekday = lambda: 0
-            base.wkday_to_mon1 = lambda x: x
-            from plone.app.widgets import utils
-            # reload utils, so that plone.app.event mock import
-            # works, even if it was imported before.
-            reload_module(utils)
-            orig_HAS_PAE = utils.HAS_PAE
-            utils.HAS_PAE = True
-            self.assertEqual(utils.first_weekday(), 0)
-            base.first_weekday = lambda: 1
-            self.assertEqual(utils.first_weekday(), 1)
-            base.first_weekday = lambda: 5
-            self.assertEqual(utils.first_weekday(), 1)
-
-            # test without plone.app.event installed
-            utils.HAS_PAE = False
-            self.assertEqual(utils.first_weekday(), 0)
-
-        # restore original state
-        utils.HAS_PAE = orig_HAS_PAE
-        reload_module(utils)
 
 
 class TestQueryStringOptions(unittest.TestCase):

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -31,7 +31,7 @@ _ = MessageFactory('plone')
 
 zope.deferredimport.deprecated(
     'Import first_weekday from plone.app.event.base instead',
-    first_weekday='plone.app.event:base.first_weekday',
+    first_weekday='plone.app.event.base:first_weekday',
 )
 
 

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -23,16 +23,16 @@ from zope.i18nmessageid import MessageFactory
 from zope.schema.interfaces import IVocabularyFactory
 
 import json
+import zope.deferredimport
 
 
 _ = MessageFactory('plone')
 
 
-def first_weekday():
-    wkday = pae_base.wkday_to_mon1(pae_base.first_weekday())
-    if wkday > 1:
-        return 1  # Default to Monday
-    return wkday
+zope.deferredimport.deprecated(
+    'Import first_weekday from plone.app.event.base instead',
+    first_weekday='plone.app.event:base.first_weekday',
+)
 
 
 class NotImplemented(Exception):

--- a/plone/app/widgets/utils.py
+++ b/plone/app/widgets/utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-
 from Acquisition import aq_base
 from Acquisition import aq_parent
 from datetime import datetime
 from OFS.interfaces import IFolder
 from OFS.interfaces import ISimpleItem
+from plone.app.event import base as pae_base
 from plone.app.layout.navigation.root import getNavigationRootObject
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.utils import getToolByName
@@ -12,8 +12,8 @@ from Products.CMFPlone.utils import get_top_site_from_url
 from z3c.form.interfaces import IForm
 from zope.component import ComponentLookupError
 from zope.component import getMultiAdapter
-from zope.component import providedBy
 from zope.component import getUtility
+from zope.component import providedBy
 from zope.component import queryUtility
 from zope.component.hooks import getSite
 from zope.deprecation import deprecate
@@ -28,26 +28,11 @@ import json
 _ = MessageFactory('plone')
 
 
-try:
-    from plone.app.event import base as pae_base
-    HAS_PAE = True
-except ImportError:
-    HAS_PAE = False
-
-
 def first_weekday():
-    if HAS_PAE:
-        wkday = pae_base.wkday_to_mon1(pae_base.first_weekday())
-        if wkday > 1:
-            return 1  # Default to Monday
-        return wkday
-    else:
-        cal = getToolByName(getSite(), 'portal_calendar', None)
-        if cal:
-            wkday = cal.firstweekday
-            if wkday == 6:  # portal_calendar's Sunday is 6
-                return 0  # Sunday
-        return 1  # other cases: Monday
+    wkday = pae_base.wkday_to_mon1(pae_base.first_weekday())
+    if wkday > 1:
+        return 1  # Default to Monday
+    return wkday
 
 
 class NotImplemented(Exception):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.4.2.dev0'
+version = '3.0.0.dev0'
 
 setup(
     name='plone.app.widgets',


### PR DESCRIPTION
Deprecate it.

Refactor get_relateditems_options to be more specific.

More cleanup would be needed.