### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/news/195.bugfix
+++ b/news/195.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]

--- a/plone/app/widgets/tests/robot/test_datetime_widget.robot
+++ b/plone/app/widgets/tests/robot/test_datetime_widget.robot
@@ -2,12 +2,13 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 Resource  common.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Variables ****************************************************************
@@ -75,4 +76,3 @@ Page should contain date
 Page should contain time
   [Arguments]  ${fieldlabel}  ${time}
   Page should contain  ${time}
-

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -1,9 +1,11 @@
 *** Settings ***
 
+Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 Resource  common.robot
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Variables ***
 ${querywidget_selector}  \#formfield-form-widgets-ICollection-query

--- a/plone/app/widgets/tests/robot/test_select_widget.robot
+++ b/plone/app/widgets/tests/robot/test_select_widget.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 
-Resource  common.robot
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
+Resource  common.robot
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Variables ***


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

Also re-enabled two previously disabled Robot tests.

In tandem with plone/plone.app.robotframework#110
Closes https://github.com/plone/plone.app.widgets/issues/195

This one actually stabilised a test for me locally when using a headless browser:
`As a contributor I can enter the date and time (test_datetime_widget.robot)`