### PR TITLE
fix commented out syntax (was a invalid heading)

### DIFF
--- a/news/197.bugfix
+++ b/news/197.bugfix
@@ -1,0 +1,1 @@
+Fix comment syntax in robot-test. [pbauer]

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -26,23 +26,23 @@ Querystring Widget rows appear and disappear correctly
         Wait Until Page Does Not Contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
 
 
-*** Comment out until we can figure out what is wrong with this test... ***
+# Comment out until we can figure out what is wrong with this test...
 
-*** Querystring Widget date criteria master/select behaviour is correct ***
-***  Given I'm logged in as a 'Site Administrator'  ***
-***    And I create a collection  My Collection ***
-***   When I select criteria index in row  1  Expiration date ***
-***        Date criteria operators are functional  1 ***
-***   When I select criteria index in row  1  Event end date ***
-***       Date criteria operators are functional  1 ***
-***  When I select criteria index in row  1  Effective date ***
-***       Date criteria operators are functional  1 ***
-***  When I select criteria index in row  1  Event start date ***
-***       Date criteria operators are functional  1 ***
-***  When I select criteria index in row  1  Creation date ***
-***       Date criteria operators are functional  1 ***
-***  When I select criteria index in row  1  Modification date ***
-***       Date criteria operators are functional  1 ***
+# Querystring Widget date criteria master/select behaviour is correct
+#  Given I'm logged in as a 'Site Administrator'
+#    And I create a collection  My Collection
+#   When I select criteria index in row  1  Expiration date
+#        Date criteria operators are functional  1
+#   When I select criteria index in row  1  Event end date
+#       Date criteria operators are functional  1
+#  When I select criteria index in row  1  Effective date
+#       Date criteria operators are functional  1
+#  When I select criteria index in row  1  Event start date
+#       Date criteria operators are functional  1
+#  When I select criteria index in row  1  Creation date
+#       Date criteria operators are functional  1
+#  When I select criteria index in row  1  Modification date
+#       Date criteria operators are functional  1
 
 
 Querystring Widget text criteria master/select behaviour is correct


### PR DESCRIPTION
That creates errrors with newest versions of robotframework:

```
[ ERROR ] Error in file '/Users/pbauer/.cache/buildout/eggs/plone.app.widgets-3.0.0-py3.7.egg/plone/app/widgets/tests/robot/test_querystring_widget.robot': Unrecognized table header 'Comment out until we can figure out what is wrong with this test...'. Available headers for data: 'Setting(s)', 'Variable(s)', 'Test Case(s)', 'Task(s)' and 'Keyword(s)'. Use 'Comment(s)' to embedded additional data.
```