### PR TITLE
Robot tests: Replace deprecated jQuery.size with generic JavaScript.

### DIFF
--- a/news/207.bugfix
+++ b/news/207.bugfix
@@ -1,0 +1,2 @@
+Robot tests: Fix deprecated jQuery.size.
+[thet]

--- a/plone/app/widgets/tests/robot/common.robot
+++ b/plone/app/widgets/tests/robot/common.robot
@@ -38,11 +38,11 @@ I edit
 I create a collection
   [Arguments]  ${title}
   Go to  ${PLONE_URL}/++add++Collection
-  Wait For Condition  return $('body.patterns-loaded').size() > 0
+  Wait For Condition  return !!document.querySelector('body.patterns-loaded')
   Execute Javascript  $('#form-widgets-IDublinCore-title').val('${title}'); return 0;
 
 I create a folder
   [Arguments]  ${title}
   Go to  ${PLONE_URL}/++add++Folder
-  Wait For Condition  return $('body.patterns-loaded').size() > 0
+  Wait For Condition  return !!document.querySelector('body.patterns-loaded')
   Execute Javascript  $('#form-widgets-IDublinCore-title').val('${title}'); return 0;

--- a/plone/app/widgets/tests/robot/test_datetime_widget.robot
+++ b/plone/app/widgets/tests/robot/test_datetime_widget.robot
@@ -31,7 +31,7 @@ As a contributor I can enter the date and time
    When I fill datetime field  Publishing Date  2010  1  30  4:00 a.m.
     And When I save
     And When I edit
-    Wait For Condition  return $('.autotoc-nav .active:visible').size() > 0
+    Wait For Condition  return $('.autotoc-nav .active:visible').length > 0
     And When I open tab  Dates
    Then Page should contain datetime  Publishing Date  2010  1  30  4:00 a.m.
 

--- a/plone/app/widgets/tests/robot/test_querystring_widget.robot
+++ b/plone/app/widgets/tests/robot/test_querystring_widget.robot
@@ -15,7 +15,7 @@ ${querywidget_selector}  \#formfield-form-widgets-ICollection-query
 Querystring Widget rows appear and disappear correctly
   Given I'm logged in as a 'Site Administrator'
     And I create a collection  My Collection
-        Wait For Condition  return $('body.patterns-loaded').size() > 0
+        Wait For Condition  return !!document.querySelector('body.patterns-loaded')
         Wait until page contains Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(1)
         Wait Until Page Does Not Contain Element  css=${querywidget_selector} .querystring-criteria-wrapper:nth-child(2)
    When I select criteria index in row  1  Expiration date

--- a/plone/app/widgets/tests/robot/test_select_widget.robot
+++ b/plone/app/widgets/tests/robot/test_select_widget.robot
@@ -71,26 +71,26 @@ a logged-in member
 
 I type on the autocomplete field
   [Arguments]  ${text}
-  Wait For Condition  return $('.select2-choices:visible').size() > 0
+  Wait For Condition  return $('.select2-choices:visible').length > 0
   Open Dropdown  ${dropdown_select}  ${input_search}
   Input Text  ${input_search}  ${text}
   Click Element  ${results_label}
 
 I type on the multiple autocomplete field
   [Arguments]  ${text}
-  Wait For Condition  return $('.select2-choices:visible').size() > 0
+  Wait For Condition  return $('.select2-choices:visible').length > 0
   Execute Javascript  var $input = $('.select2-input'); $input.click().val('${text}'); var keyup = $.Event('keyup-change'); $input.trigger(keyup); return 0
   Click Element  ${results_label}
 
 I select the option
   [Arguments]  ${index}
-  Wait For Condition  return $('.select2-choices:visible').size() > 0
+  Wait For Condition  return $('.select2-choices:visible').length > 0
   Open Dropdown  ${dropdown_select}  ${input_search}
   Click Element  css=li.select2-results-dept-0:nth-child(${index})
 
 I click on the element
   [Arguments]  ${index}
-  Wait For Condition  return $('.select2-choices:visible').size() > 0
+  Wait For Condition  return $('.select2-choices:visible').length > 0
   Open Dropdown  css=#formfield-form-widgets-list_field input.select2-input  ${dropdown_multiple}
   Click Element  css=li.select2-results-dept-0:nth-child(${index})
 


### PR DESCRIPTION
jQuery.size is deprecated since jQuery 1.8 and not available in jQuery 3.